### PR TITLE
feat: 전역 UI 메시징을 위한 MessageHelper 추가

### DIFF
--- a/app/src/main/java/io/soma/cryptobook/di/MessageModule.kt
+++ b/app/src/main/java/io/soma/cryptobook/di/MessageModule.kt
@@ -1,0 +1,20 @@
+package io.soma.cryptobook.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import io.soma.cryptobook.core.domain.message.MessageHelper
+import io.soma.cryptobook.main.presentation.message.MessageCommandSource
+import io.soma.cryptobook.main.presentation.message.MessageHelperImpl
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class MessageModule {
+
+    @Binds
+    abstract fun bindMessageHelper(impl: MessageHelperImpl): MessageHelper
+
+    @Binds
+    abstract fun bindMessageCommandSource(impl: MessageHelperImpl): MessageCommandSource
+}

--- a/core/domain/src/main/java/io/soma/cryptobook/core/domain/message/MessageHelper.kt
+++ b/core/domain/src/main/java/io/soma/cryptobook/core/domain/message/MessageHelper.kt
@@ -1,0 +1,9 @@
+package io.soma.cryptobook.core.domain.message
+
+interface MessageHelper {
+    fun showLoading()
+    fun hideLoading()
+    fun showToast(message: String)
+    fun showSnackbar(message: String, actionLabel: String? = null, onAction: (() -> Unit)? = null)
+    fun dismissSnackbar()
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ okhttp = "4.12.0"
 protobuf = "4.29.2"
 protobufPlugin = "0.9.5"
 kotlinxSerializationJson = "1.8.0"
+kotlinxAtomicfu = "0.29.0"
 coroutines = "1.10.2"
 navigation3 = "1.0.0"
 spotless = "6.25.0"
@@ -73,6 +74,7 @@ okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor",
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
+kotlinx-atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "kotlinxAtomicfu" }
 androidx-navigation3-runtime = { group = "androidx.navigation3", name = "navigation3-runtime", version.ref = "navigation3" }
 androidx-navigation3-ui = { group = "androidx.navigation3", name = "navigation3-ui", version.ref = "navigation3" }
 androidx-lifecycle-viewmodel-navigation3 = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-navigation3", version.ref = "navigation3" }

--- a/home/presentation/src/main/java/io/soma/cryptobook/home/presentation/HomeScreen.kt
+++ b/home/presentation/src/main/java/io/soma/cryptobook/home/presentation/HomeScreen.kt
@@ -1,6 +1,5 @@
 package io.soma.cryptobook.home.presentation
 
-import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -19,7 +18,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -30,7 +28,6 @@ import java.math.RoundingMode
 @Composable
 fun HomeRoute(modifier: Modifier = Modifier, viewModel: HomeViewModel = hiltViewModel()) {
     val uiState by viewModel.state.collectAsStateWithLifecycle()
-    val context = LocalContext.current
 
     viewModel.sideEffect.collectWithLifecycle { effect ->
         when (effect) {
@@ -39,7 +36,9 @@ fun HomeRoute(modifier: Modifier = Modifier, viewModel: HomeViewModel = hiltView
             )
 
             is HomeSideEffect.ShowToast -> {
-                Toast.makeText(context, effect.message, Toast.LENGTH_SHORT).show()
+                // TODO(hs) : 현재 sideEffect 처리 부분은 ViewModel로 옮겨져야 합니다.
+                //
+                viewModel.messageHelper.showToast(effect.message)
             }
 
             HomeSideEffect.Close -> {

--- a/home/presentation/src/main/java/io/soma/cryptobook/home/presentation/HomeViewModel.kt
+++ b/home/presentation/src/main/java/io/soma/cryptobook/home/presentation/HomeViewModel.kt
@@ -2,6 +2,7 @@ package io.soma.cryptobook.home.presentation
 
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import io.soma.cryptobook.core.domain.message.MessageHelper
 import io.soma.cryptobook.core.domain.navigation.NavigationHelper
 import io.soma.cryptobook.core.presentation.BaseViewModel
 import io.soma.cryptobook.home.domain.usecase.GetCoinListUseCase
@@ -14,6 +15,7 @@ class HomeViewModel @Inject constructor(
     private val getCoinListUseCase: GetCoinListUseCase,
     private val observeCoinListUseCase: ObserveCoinListUseCase,
     val navigationHelper: NavigationHelper,
+    val messageHelper: MessageHelper,
 ) : BaseViewModel<HomeEvent, HomeUiState, HomeSideEffect>(HomeUiState()) {
 
     init {
@@ -97,7 +99,7 @@ class HomeViewModel @Inject constructor(
 
             is GetCoinListUseCase.Result.Error.Server,
             is GetCoinListUseCase.Result.Error.Unknown,
-                -> {
+            -> {
                 sendSideEffect { HomeSideEffect.ShowToast("잠시 후 다시 시도해주세요") }
             }
         }

--- a/main/presentation/build.gradle.kts
+++ b/main/presentation/build.gradle.kts
@@ -19,6 +19,8 @@ dependencies {
     implementation(libs.androidx.navigation3.ui)
     implementation(libs.androidx.lifecycle.viewmodel.navigation3)
 
+    implementation(libs.kotlinx.atomicfu)
+
     implementation(libs.androidx.compose.material3.adaptive)
     implementation(libs.androidx.compose.material3.adaptive.layout)
     implementation(libs.androidx.compose.material3.adaptive.navigation)

--- a/main/presentation/src/main/java/io/soma/cryptobook/main/presentation/CryptoBookApp.kt
+++ b/main/presentation/src/main/java/io/soma/cryptobook/main/presentation/CryptoBookApp.kt
@@ -1,5 +1,8 @@
 package io.soma.cryptobook.main.presentation
 
+import android.widget.Toast
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
@@ -10,14 +13,25 @@ import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Text
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.NavKey
@@ -27,6 +41,8 @@ import androidx.navigation3.ui.NavDisplay
 import io.soma.cryptobook.coindetail.presentation.navigation.coinDetailEntry
 import io.soma.cryptobook.home.presentation.navigation.HomeNavKey
 import io.soma.cryptobook.home.presentation.navigation.homeEntry
+import io.soma.cryptobook.main.presentation.message.MessageCommand
+import io.soma.cryptobook.main.presentation.message.MessageCommandSource
 import io.soma.cryptobook.main.presentation.navigation.CbNavigator
 import io.soma.cryptobook.main.presentation.navigation.LinkRouter
 import io.soma.cryptobook.main.presentation.navigation.NavCommand
@@ -38,16 +54,22 @@ import io.soma.cryptobook.settings.presentation.navigation.settingsEntry
 @Composable
 fun CryptoBookApp(
     navSource: NavCommandSource,
+    messageSource: MessageCommandSource,
     linkRouter: LinkRouter,
     appLinkKey: NavKey,
     modifier: Modifier = Modifier,
 ) {
+    // navigation
     val navigationState = rememberNavigationState(HomeNavKey, TOP_LEVEL_NAV_ITEMS.keys)
     if (appLinkKey !is HomeNavKey) {
         navigationState.backStack.add(appLinkKey)
     }
-
     val navigator = remember { CbNavigator(navigationState) }
+
+    // message
+    var isLoading by remember { mutableStateOf(false) }
+    val snackbarHostState = remember { SnackbarHostState() }
+    val context = LocalContext.current
 
     LaunchedEffect(Unit) {
         navSource.commands.collect { cmd ->
@@ -70,6 +92,33 @@ fun CryptoBookApp(
         }
     }
 
+    LaunchedEffect(Unit) {
+        messageSource.commands.collect { cmd ->
+            when (cmd) {
+                is MessageCommand.ShowLoading -> isLoading = true
+                is MessageCommand.HideLoading -> isLoading = false
+                is MessageCommand.ShowToast -> {
+                    Toast.makeText(context, cmd.message, Toast.LENGTH_SHORT).show()
+                }
+
+                is MessageCommand.ShowSnackbar -> {
+                    val result = snackbarHostState.showSnackbar(
+                        message = cmd.message,
+                        actionLabel = cmd.actionLabel,
+                        duration = SnackbarDuration.Short,
+                    )
+                    if (result == SnackbarResult.ActionPerformed) {
+                        cmd.onAction?.invoke()
+                    }
+                }
+
+                is MessageCommand.DismissSnackbar -> {
+                    snackbarHostState.currentSnackbarData?.dismiss()
+                }
+            }
+        }
+    }
+
     NavigationSuiteScaffold(
         navigationSuiteItems = {
             TOP_LEVEL_NAV_ITEMS.forEach { (navKey, navItem) ->
@@ -86,6 +135,7 @@ fun CryptoBookApp(
     ) {
         Scaffold(
             modifier = modifier,
+            snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
             contentWindowInsets = WindowInsets(0, 0, 0, 0),
         ) { padding ->
             Column(
@@ -120,6 +170,18 @@ fun CryptoBookApp(
                     )
                 }
             }
+        }
+    }
+
+    if (isLoading) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black.copy(alpha = 0.5f))
+                .clickable(enabled = false) { },
+            contentAlignment = Alignment.Center,
+        ) {
+            CircularProgressIndicator(color = Color.Black)
         }
     }
 }

--- a/main/presentation/src/main/java/io/soma/cryptobook/main/presentation/MainActivity.kt
+++ b/main/presentation/src/main/java/io/soma/cryptobook/main/presentation/MainActivity.kt
@@ -11,6 +11,7 @@ import androidx.navigation3.runtime.NavKey
 import dagger.hilt.android.AndroidEntryPoint
 import io.soma.cryptobook.core.domain.navigation.NavigationHelper
 import io.soma.cryptobook.home.presentation.navigation.HomeNavKey
+import io.soma.cryptobook.main.presentation.message.MessageCommandSource
 import io.soma.cryptobook.main.presentation.navigation.LinkRouter
 import io.soma.cryptobook.main.presentation.navigation.NavCommandSource
 import io.soma.cryptobook.main.presentation.splash.SplashViewModel
@@ -26,6 +27,9 @@ class MainActivity : ComponentActivity() {
 
     @Inject
     lateinit var navSource: NavCommandSource
+
+    @Inject
+    lateinit var messageSource: MessageCommandSource
 
     @Inject
     lateinit var navigationHelper: NavigationHelper
@@ -48,6 +52,7 @@ class MainActivity : ComponentActivity() {
             CryptoBookApp(
                 navSource = navSource,
                 linkRouter = linkRouter,
+                messageSource = messageSource,
                 appLinkKey = appLinkKey,
             )
         }

--- a/main/presentation/src/main/java/io/soma/cryptobook/main/presentation/message/MessageCommand.kt
+++ b/main/presentation/src/main/java/io/soma/cryptobook/main/presentation/message/MessageCommand.kt
@@ -1,0 +1,20 @@
+package io.soma.cryptobook.main.presentation.message
+
+import kotlinx.coroutines.flow.SharedFlow
+
+sealed interface MessageCommand {
+    data object ShowLoading : MessageCommand
+    data object HideLoading : MessageCommand
+    data class ShowToast(val message: String) : MessageCommand
+    data class ShowSnackbar(
+        val message: String,
+        val actionLabel: String? = null,
+        val onAction: (() -> Unit)? = null,
+    ) : MessageCommand
+
+    data object DismissSnackbar : MessageCommand
+}
+
+interface MessageCommandSource {
+    val commands: SharedFlow<MessageCommand>
+}

--- a/main/presentation/src/main/java/io/soma/cryptobook/main/presentation/message/MessageHelperImpl.kt
+++ b/main/presentation/src/main/java/io/soma/cryptobook/main/presentation/message/MessageHelperImpl.kt
@@ -1,0 +1,46 @@
+package io.soma.cryptobook.main.presentation.message
+
+import io.soma.cryptobook.core.domain.message.MessageHelper
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class MessageHelperImpl @Inject constructor() : MessageHelper, MessageCommandSource {
+    private val loadingCount = atomic(0)
+
+    private val _commands = MutableSharedFlow<MessageCommand>(
+        extraBufferCapacity = 64,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
+    override val commands: SharedFlow<MessageCommand> = _commands.asSharedFlow()
+
+    override fun showLoading() {
+        if (loadingCount.incrementAndGet() == 1) {
+            _commands.tryEmit(MessageCommand.ShowLoading)
+        }
+    }
+
+    override fun hideLoading() {
+        if (loadingCount.decrementAndGet() == 0) {
+            _commands.tryEmit(MessageCommand.HideLoading)
+        }
+    }
+
+    override fun showToast(message: String) {
+        _commands.tryEmit(MessageCommand.ShowToast(message))
+    }
+
+    override fun showSnackbar(message: String, actionLabel: String?, onAction: (() -> Unit)?) {
+        _commands.tryEmit(MessageCommand.ShowSnackbar(message, actionLabel, onAction))
+    }
+
+    override fun dismissSnackbar() {
+        _commands.tryEmit(MessageCommand.DismissSnackbar)
+    }
+}

--- a/settings/domain/src/main/java/io/soma/cryptobook/settings/domain/usecase/TempLoadingMessageUseCase.kt
+++ b/settings/domain/src/main/java/io/soma/cryptobook/settings/domain/usecase/TempLoadingMessageUseCase.kt
@@ -1,0 +1,15 @@
+package io.soma.cryptobook.settings.domain.usecase
+
+import io.soma.cryptobook.core.domain.message.MessageHelper
+import kotlinx.coroutines.delay
+import javax.inject.Inject
+
+class TempLoadingMessageUseCase @Inject constructor(
+    private val messageHelper: MessageHelper,
+) {
+    suspend operator fun invoke() {
+        messageHelper.showLoading()
+        delay(3000L)
+        messageHelper.hideLoading()
+    }
+}

--- a/settings/domain/src/main/java/io/soma/cryptobook/settings/domain/usecase/TempSnackbarMessageUseCase.kt
+++ b/settings/domain/src/main/java/io/soma/cryptobook/settings/domain/usecase/TempSnackbarMessageUseCase.kt
@@ -1,0 +1,16 @@
+package io.soma.cryptobook.settings.domain.usecase
+
+import io.soma.cryptobook.core.domain.message.MessageHelper
+import javax.inject.Inject
+
+class TempSnackbarMessageUseCase @Inject constructor(
+    private val messageHelper: MessageHelper,
+) {
+    operator fun invoke() {
+        messageHelper.showSnackbar(
+            message = "스낵바 테스트 메시지입니다",
+            actionLabel = "확인",
+            onAction = { },
+        )
+    }
+}

--- a/settings/presentation/src/main/java/io/soma/cryptobook/settings/presentation/SettingsScreen.kt
+++ b/settings/presentation/src/main/java/io/soma/cryptobook/settings/presentation/SettingsScreen.kt
@@ -114,5 +114,22 @@ internal fun SettingsScreen(
         ) {
             Text(text = "[임시] 홈으로 이동")
         }
+
+        // Temporary Message Button
+        Spacer(modifier = Modifier.height(8.dp))
+        Button(
+            onClick = { onEvent(SettingsEvent.ShowLoadingMessage) },
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(text = "[임시] 로딩 테스트 (3초)")
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+        Button(
+            onClick = { onEvent(SettingsEvent.ShowSnackbarMessage) },
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(text = "[임시] 스낵바 테스트")
+        }
     }
 }

--- a/settings/presentation/src/main/java/io/soma/cryptobook/settings/presentation/SettingsViewModel.kt
+++ b/settings/presentation/src/main/java/io/soma/cryptobook/settings/presentation/SettingsViewModel.kt
@@ -7,7 +7,9 @@ import io.soma.cryptobook.settings.domain.model.UserData
 import io.soma.cryptobook.settings.domain.usecase.GetUserDataUseCase
 import io.soma.cryptobook.settings.domain.usecase.SetLanguageUseCase
 import io.soma.cryptobook.settings.domain.usecase.SetPriceCurrencyUseCase
+import io.soma.cryptobook.settings.domain.usecase.TempLoadingMessageUseCase
 import io.soma.cryptobook.settings.domain.usecase.TempNavigateToHomeUseCase
+import io.soma.cryptobook.settings.domain.usecase.TempSnackbarMessageUseCase
 import io.soma.cryptobook.settings.presentation.base.MviViewModel
 import javax.inject.Inject
 
@@ -25,6 +27,8 @@ sealed interface SettingsEvent {
     data class SetLanguage(val language: Language) : SettingsEvent
     data class SetCurrencyUnit(val currencyUnit: CurrencyUnit) : SettingsEvent
     data object NavigateToHome : SettingsEvent
+    data object ShowLoadingMessage : SettingsEvent
+    data object ShowSnackbarMessage : SettingsEvent
 }
 
 @HiltViewModel
@@ -33,6 +37,8 @@ class SettingsViewModel @Inject constructor(
     private val setLanguageUseCase: SetLanguageUseCase,
     private val setPriceCurrencyUseCase: SetPriceCurrencyUseCase,
     private val tempNavigateToHomeUseCase: TempNavigateToHomeUseCase,
+    private val tempLoadingMessageUseCase: TempLoadingMessageUseCase,
+    private val tempSnackbarMessageUseCase: TempSnackbarMessageUseCase,
 ) : MviViewModel<SettingsState, SettingsSideEffect>(SettingsState()) {
     init {
         intent {
@@ -51,6 +57,8 @@ class SettingsViewModel @Inject constructor(
             is SettingsEvent.SetLanguage -> onLanguageChanged(event.language)
             is SettingsEvent.SetCurrencyUnit -> onPriceCurrencyChanged(event.currencyUnit)
             is SettingsEvent.NavigateToHome -> navigateToHome()
+            is SettingsEvent.ShowLoadingMessage -> showLoadingMessage()
+            is SettingsEvent.ShowSnackbarMessage -> showSnackbarMessage()
         }
     }
 
@@ -76,5 +84,13 @@ class SettingsViewModel @Inject constructor(
 
     private fun navigateToHome() = intent {
         tempNavigateToHomeUseCase()
+    }
+
+    private fun showLoadingMessage() = intent {
+        tempLoadingMessageUseCase()
+    }
+
+    private fun showSnackbarMessage() {
+        tempSnackbarMessageUseCase()
     }
 }


### PR DESCRIPTION
## 관련 이슈
- Closes #15 

## 사전 점검

- [X] `./gradlew spotlessApply` 실행을 완료하였습니다.

## 작업 개요

### Summary

- Domain 레이어에서 호출 가능한 전역 UI 메시징 시스템 추가
- NavigationHelper 패턴을 따라 MessageHelper 구현
- 로딩 오버레이, 토스트, 스낵바 지원

### Changes

- core/domain: MessageHelper 인터페이스 추가
- main/presentation: MessageHelperImpl 구현 (SharedFlow 기반)
- app/di: MessageModule DI 바인딩 추가
- home: Toast.makeText → MessageHelper.showToast 전환
- settings: 테스트용 임시 버튼 추가

## 리뷰어 집중 포인트(참고 사항)

- Settings 화면에서 로딩 테스트 버튼 클릭 → 3초간 로딩 오버레이 표시 확인
- Settings 화면에서 스낵바 테스트 버튼 클릭 → 스낵바 표시 확인
- Home 화면에서 에러 발생 시 토스트 표시 확인

## 후속 작업
-
