### PR TITLE
feat(build): JVM 라이브러리 컨벤션 플러그인 추가 및 domain 모듈 마이그레이션

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -35,6 +35,10 @@ gradlePlugin {
             id = libs.plugins.cryptobook.android.presentation.get().pluginId
             implementationClass = "AndroidPresentationConventionPlugin"
         }
+        register("jvmLibrary") {
+            id = libs.plugins.cryptobook.jvm.library.get().pluginId
+            implementationClass = "JvmLibraryConventionPlugin"
+        }
         register("spotless") {
             id = libs.plugins.cryptobook.spotless.get().pluginId
             implementationClass = "SpotlessConventionPlugin"

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -1,11 +1,11 @@
 import com.android.build.api.dsl.LibraryExtension
 import io.soma.cryptobook.configureKotlinAndroid
+import io.soma.cryptobook.libs
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.getByType
-import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
+import org.gradle.kotlin.dsl.dependencies
 
 class AndroidLibraryConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
@@ -15,11 +15,12 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
 
             extensions.configure<LibraryExtension> {
                 configureKotlinAndroid(this)
-                defaultConfig.targetSdk = 36
+                testOptions.targetSdk = 36
             }
 
-            extensions.getByType<KotlinAndroidProjectExtension>().apply {
-                configureKotlinAndroid(this)
+            dependencies {
+                "androidTestImplementation"(libs.findLibrary("kotlin.test").get())
+                "testImplementation"(libs.findLibrary("kotlin.test").get())
             }
         }
     }

--- a/build-logic/convention/src/main/kotlin/JvmLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/JvmLibraryConventionPlugin.kt
@@ -1,0 +1,19 @@
+import io.soma.cryptobook.configureKotlinJvm
+import io.soma.cryptobook.libs
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.dependencies
+
+class JvmLibraryConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            apply(plugin = "org.jetbrains.kotlin.jvm")
+
+            configureKotlinJvm()
+            dependencies {
+                "testImplementation"(libs.findLibrary("kotlin.test").get())
+            }
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/io.soma.cryptobook/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/io.soma.cryptobook/KotlinAndroid.kt
@@ -3,8 +3,11 @@ package io.soma.cryptobook
 import com.android.build.api.dsl.CommonExtension
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.kotlin.dsl.configure
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 
 internal fun Project.configureKotlinAndroid(
     commonExtension: CommonExtension<*, *, *, *, *, *>,
@@ -21,12 +24,20 @@ internal fun Project.configureKotlinAndroid(
             targetCompatibility = JavaVersion.VERSION_17
         }
     }
+    extensions.configure<KotlinAndroidProjectExtension> {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+        }
+    }
 }
 
-internal fun Project.configureKotlinAndroid(
-    extension: KotlinAndroidProjectExtension,
-) {
-    extension.apply {
+internal fun Project.configureKotlinJvm() {
+    extensions.configure<JavaPluginExtension> {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    extensions.configure<KotlinJvmProjectExtension> {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_17)
         }

--- a/coin-detail/domain/build.gradle.kts
+++ b/coin-detail/domain/build.gradle.kts
@@ -1,17 +1,7 @@
 plugins {
-    id("java-library")
-    alias(libs.plugins.jetbrains.kotlin.jvm)
+    alias(libs.plugins.cryptobook.jvm.library)
     alias(libs.plugins.cryptobook.hilt)
     alias(libs.plugins.cryptobook.spotless)
-}
-java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
-}
-kotlin {
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
-    }
 }
 
 dependencies {

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -1,17 +1,7 @@
 plugins {
-    id("java-library")
-    alias(libs.plugins.jetbrains.kotlin.jvm)
+    alias(libs.plugins.cryptobook.jvm.library)
     alias(libs.plugins.cryptobook.hilt)
     alias(libs.plugins.cryptobook.spotless)
-}
-java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
-}
-kotlin {
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
-    }
 }
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -90,6 +90,8 @@ room-gradlePlugin = { group = "androidx.room", name = "room-gradle-plugin", vers
 spotless-gradlePlugin = { group = "com.diffplug.spotless", name = "spotless-plugin-gradle", version.ref = "spotless" }
 material = { group = "com.google.android.material", name = "material", version.ref = "materialVersion" }
 androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics", version.ref = "uiGraphics" }
+kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test", version.ref = "kotlin" }
+
 
 
 [plugins]
@@ -110,4 +112,5 @@ cryptobook-android-library = { id = "cryptobook.android.library" }
 cryptobook-hilt = { id = "cryptobook.hilt" }
 cryptobook-android-library-compose = { id = "cryptobook.android.library.compose" }
 cryptobook-android-presentation = { id = "cryptobook.android.presentation" }
+cryptobook-jvm-library = { id = "cryptobook.jvm.library" }
 cryptobook-spotless = { id = "cryptobook.spotless" }

--- a/home/domain/build.gradle.kts
+++ b/home/domain/build.gradle.kts
@@ -1,17 +1,7 @@
 plugins {
-    id("java-library")
-    alias(libs.plugins.jetbrains.kotlin.jvm)
+    alias(libs.plugins.cryptobook.jvm.library)
     alias(libs.plugins.cryptobook.hilt)
     alias(libs.plugins.cryptobook.spotless)
-}
-java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
-}
-kotlin {
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
-    }
 }
 
 dependencies {

--- a/main/domain/build.gradle.kts
+++ b/main/domain/build.gradle.kts
@@ -1,14 +1,5 @@
 plugins {
-    id("java-library")
-    alias(libs.plugins.jetbrains.kotlin.jvm)
+    alias(libs.plugins.cryptobook.jvm.library)
+    alias(libs.plugins.cryptobook.hilt)
     alias(libs.plugins.cryptobook.spotless)
-}
-java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
-}
-kotlin {
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
-    }
 }

--- a/settings/domain/build.gradle.kts
+++ b/settings/domain/build.gradle.kts
@@ -1,17 +1,7 @@
 plugins {
-    id("java-library")
-    alias(libs.plugins.jetbrains.kotlin.jvm)
+    alias(libs.plugins.cryptobook.jvm.library)
     alias(libs.plugins.cryptobook.hilt)
     alias(libs.plugins.cryptobook.spotless)
-}
-java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
-}
-kotlin {
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
-    }
 }
 
 dependencies {

--- a/splash/domain/build.gradle.kts
+++ b/splash/domain/build.gradle.kts
@@ -1,17 +1,7 @@
 plugins {
-    id("java-library")
-    alias(libs.plugins.jetbrains.kotlin.jvm)
+    alias(libs.plugins.cryptobook.jvm.library)
     alias(libs.plugins.cryptobook.hilt)
     alias(libs.plugins.cryptobook.spotless)
-}
-java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
-}
-kotlin {
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
-    }
 }
 
 dependencies {


### PR DESCRIPTION

## 관련 이슈
- Closes #34

## 사전 점검

- [X] `./gradlew spotlessApply` 실행을 완료하였습니다.

## 작업 개요
## 요약
- JVM 라이브러리 모듈의 빌드 설정을 표준화하기 위한 컨벤션 플러그인 추가
- 모든 domain 모듈을 새로운 컨벤션 플러그인으로 마이그레이션하여 중복 제거
- Android 라이브러리 컨벤션 플러그인 개선

## 주요 변경사항

### 1. JvmLibraryConventionPlugin 추가
- `JvmLibraryConventionPlugin.kt` 신규 생성
- JVM 라이브러리의 공통 설정 자동화
- Kotlin JVM 플러그인 적용
- Java 17 호환성 설정
- kotlin-test 의존성 자동 추가

### 2. Domain 모듈 마이그레이션 (6개 모듈)
다음 모듈들의 `build.gradle.kts`에서 중복 코드 제거:
- `coin-detail/domain`
- `core/domain`
- `home/domain`
- `main/domain`
- `settings/domain`
- `splash/domain`

**변경 전:**
```kotlin
plugins {
  id("java-library")
  alias(libs.plugins.jetbrains.kotlin.jvm)
}
java {
  sourceCompatibility = JavaVersion.VERSION_17
  targetCompatibility = JavaVersion.VERSION_17
}
kotlin {
  compilerOptions {
    jvmTarget = JvmTarget.JVM_17
  }
}
```

변경 후:
```
plugins {
  alias(libs.plugins.cryptobook.jvm.library)
}
```

### 3. AndroidLibraryConventionPlugin 개선
- kotlin-test 의존성 자동 추가 (androidTest, test)
- defaultConfig.targetSdk → testOptions.targetSdk 수정
- 불필요한 KotlinAndroidProjectExtension 설정 제거

### 4. KotlinAndroid.kt 리팩토링
- configureKotlinJvm() 함수 추가: JVM 전용 Kotlin 설정 분리
- Android와 JVM 설정 로직 명확히 구분

