### PR TITLE
feat(home): implement sorting functionality for coin list

### DIFF
--- a/home/presentation/src/main/java/io/soma/cryptobook/home/presentation/HomeContract.kt
+++ b/home/presentation/src/main/java/io/soma/cryptobook/home/presentation/HomeContract.kt
@@ -4,12 +4,15 @@ import io.soma.cryptobook.core.domain.model.CoinPriceVO
 import io.soma.cryptobook.core.presentation.Event
 import io.soma.cryptobook.core.presentation.SideEffect
 import io.soma.cryptobook.core.presentation.UiState
+import io.soma.cryptobook.home.presentation.component.sortheader.SortDirection
 import java.math.BigDecimal
 
 data class HomeUiState(
     val coins: List<CoinItem> = emptyList(),
     val isLoading: Boolean = false,
     val errorMsg: String? = null,
+    val sortField: SortField = SortField.Price,
+    val sortDirection: SortDirection = SortDirection.Desc,
 ) : UiState
 
 data class CoinItem(
@@ -18,10 +21,17 @@ data class CoinItem(
     val priceChangePercentage24h: Double,
 )
 
+enum class SortField {
+    Symbol,
+    Price,
+    Change,
+}
+
 sealed interface HomeEvent : Event {
     data object OnRefresh : HomeEvent
     data object OnBackClicked : HomeEvent
     data class OnCoinClicked(val symbol: String) : HomeEvent
+    data class OnSortClicked(val field: SortField) : HomeEvent
 }
 
 sealed interface HomeSideEffect : SideEffect

--- a/home/presentation/src/main/java/io/soma/cryptobook/home/presentation/HomeScreen.kt
+++ b/home/presentation/src/main/java/io/soma/cryptobook/home/presentation/HomeScreen.kt
@@ -64,14 +64,21 @@ internal fun HomeScreen(state: HomeUiState, onEvent: (HomeEvent) -> Unit, modifi
             }
         }
 
-        // Sort Header (TODO: 정렬 기능 구현)
+        // Sort Header
+        val symbolSort =
+            if (state.sortField == SortField.Symbol) state.sortDirection else SortDirection.None
+        val priceSort =
+            if (state.sortField == SortField.Price) state.sortDirection else SortDirection.None
+        val changeSort =
+            if (state.sortField == SortField.Change) state.sortDirection else SortDirection.None
+
         SortHeader(
-            symbolSort = SortDirection.None,
-            priceSort = SortDirection.Desc,
-            changeSort = SortDirection.None,
-            onSymbolClick = { /* TODO: 정렬 기능 구현 */ },
-            onPriceClick = { /* TODO: 정렬 기능 구현 */ },
-            onChangeClick = { /* TODO: 정렬 기능 구현 */ },
+            symbolSort = symbolSort,
+            priceSort = priceSort,
+            changeSort = changeSort,
+            onSymbolClick = { onEvent(HomeEvent.OnSortClicked(SortField.Symbol)) },
+            onPriceClick = { onEvent(HomeEvent.OnSortClicked(SortField.Price)) },
+            onChangeClick = { onEvent(HomeEvent.OnSortClicked(SortField.Change)) },
         )
 
         // Coin List

--- a/home/presentation/src/main/java/io/soma/cryptobook/home/presentation/HomeViewModel.kt
+++ b/home/presentation/src/main/java/io/soma/cryptobook/home/presentation/HomeViewModel.kt
@@ -6,6 +6,7 @@ import io.soma.cryptobook.core.domain.navigation.AppPage
 import io.soma.cryptobook.core.domain.navigation.NavigationHelper
 import io.soma.cryptobook.core.presentation.MviViewModel
 import io.soma.cryptobook.home.domain.usecase.ObserveCoinListUseCase
+import io.soma.cryptobook.home.presentation.component.sortheader.SortDirection
 import javax.inject.Inject
 
 @HiltViewModel
@@ -29,6 +30,7 @@ class HomeViewModel @Inject constructor(
             is HomeEvent.OnCoinClicked -> navigationHelper.navigate(
                 AppPage.CoinDetail(event.symbol),
             )
+            is HomeEvent.OnSortClicked -> updateSort(event.field)
         }
     }
 
@@ -37,11 +39,16 @@ class HomeViewModel @Inject constructor(
             observeCoinListUseCase().collect { result ->
                 when (result) {
                     is ObserveCoinListUseCase.Result.Success -> {
+                        val sortedCoins = sortCoins(
+                            coins = result.coinList.map { it.toCoinItem() },
+                            sortField = currentState.sortField,
+                            sortDirection = currentState.sortDirection,
+                        )
                         reduce {
                             copy(
                                 isLoading = false,
                                 errorMsg = null,
-                                coins = result.coinList.map { it.toCoinItem() },
+                                coins = sortedCoins,
                             )
                         }
                     }
@@ -57,6 +64,51 @@ class HomeViewModel @Inject constructor(
                     }
                 }
             }
+        }
+    }
+
+    private fun updateSort(field: SortField) {
+        val newDirection = if (field == currentState.sortField) {
+            toggleDirection(currentState.sortDirection)
+        } else {
+            defaultSortDirection(field)
+        }
+
+        reduce {
+            copy(
+                sortField = field,
+                sortDirection = newDirection,
+                coins = sortCoins(coins, field, newDirection),
+            )
+        }
+    }
+
+    private fun sortCoins(
+        coins: List<CoinItem>,
+        sortField: SortField,
+        sortDirection: SortDirection,
+    ): List<CoinItem> {
+        val comparator = when (sortField) {
+            SortField.Symbol -> compareBy<CoinItem> { it.symbol }
+            SortField.Price -> compareBy<CoinItem> { it.price }
+            SortField.Change -> compareBy<CoinItem> { it.priceChangePercentage24h }
+        }
+
+        return if (sortDirection == SortDirection.Desc) {
+            coins.sortedWith(comparator).asReversed()
+        }else{
+            coins.sortedWith(comparator)
+        }
+    }
+
+    private fun toggleDirection(current: SortDirection): SortDirection {
+        return if (current == SortDirection.Asc) SortDirection.Desc else SortDirection.Asc
+    }
+
+    private fun defaultSortDirection(field: SortField): SortDirection {
+        return when (field) {
+            SortField.Symbol -> SortDirection.Asc
+            SortField.Price, SortField.Change -> SortDirection.Desc
         }
     }
 }

--- a/home/presentation/src/main/java/io/soma/cryptobook/home/presentation/component/sortheader/SortHeaderItem.kt
+++ b/home/presentation/src/main/java/io/soma/cryptobook/home/presentation/component/sortheader/SortHeaderItem.kt
@@ -80,7 +80,7 @@ fun SortHeaderItem(
             text = label,
             fontFamily = fontFamily,
             fontWeight = FontWeight.Bold,
-            fontSize = 14.sp,
+            fontSize = 12.sp,
             lineHeight = 20.sp,
             color = textColor,
         )


### PR DESCRIPTION
## 관련 이슈
- Closes #

## 사전 점검

- [ ] `./gradlew spotlessApply` 실행을 완료하였습니다.

## 작업 개요

1. SortHeaderItem.kt에서 SortHeaderItem의 텍스트 사이즈를 14 -> 12로 변경하였습니다.
2. HomeContract.kt에서 enum class SortField를 추가하였습니다.
3. HomeContract.kt에서 data class HomeUiState에 sortField와 sortDirection을 추가하였습니다.
4. HomeContract.kt에서 sealed interface HomeEvent에 OnSortClicked를 추가하였습니다.
5. HomeViewModel.kt에서 observeCoins 함수에서 먼저 sortCoins를 진행하도록 하였습니다.
6. HomeViewModel.kt에서 updateSort와 sortCoins 함수를 추가하였습니다.
7. HomeViewModel.kt에서 toggleDirection과 defaultSortDirection 함수를 추가하였습니다.
8. HomeViewModel.kt에서 handleEvent에 HomeEvent.OnSortClicked 발생시 updateSort를 진행하도록 하였습니다.
9. HomeScreen.kt에서 SortHeader의 onSymbolClick, onPriceClick, onChangeClick에 이벤트를 연결하고, 각 Sort Ui를 업데이트도 업데이트 하도록 만들었습니다.

## 상세 내용
### 1️⃣ UI/UX 변경
| Before | After |
| :---: | :---: |
| <img src="" width="240" /> | <img width="240" height="2340" alt="image" src="https://github.com/user-attachments/assets/ff444684-e4b3-4e09-8495-5ec8fcdf3e3c" /> |

### 2️⃣ 로직 및 아키텍처
- **기존 방식:**
- **변경 방식:**

| 구분 | AS-IS (기존) | TO-BE (변경) |
| :---: | :---: | :---: |
|  |  |  정렬 기능 추가 |

### 3️⃣ 리팩토링
- 


## 리뷰어 집중 포인트(참고 사항)


## 후속 작업
- [ ] 
