### PR TITLE
refactor(data): 웹소켓 flow 전달방식 일부 수정

### DIFF
--- a/coin-detail/data/src/main/java/io/soma/cryptobook/coindetail/data/datasource/CoinDetailStreamDataSource.kt
+++ b/coin-detail/data/src/main/java/io/soma/cryptobook/coindetail/data/datasource/CoinDetailStreamDataSource.kt
@@ -16,14 +16,14 @@ import io.soma.cryptobook.core.network.session.WsSessionManager
 import io.soma.cryptobook.core.network.subscription.WsSubscriptionFailure
 import io.soma.cryptobook.core.network.subscription.WsSubscriptionManager
 import io.soma.cryptobook.core.network.subscription.WsSubscriptionMethod
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
@@ -42,14 +42,8 @@ class CoinDetailStreamDataSource @Inject constructor(
         private const val KLINE_BACKFILL_PAGE_LIMIT = 1500
     }
 
-    sealed interface State {
-        data class Success(val ticker: CoinTickerDto) : State
-        data class Error(val throwable: Throwable) : State
-        data object Connected : State
-        data object Disconnected : State
-    }
-
-    fun observeCoinDetail(symbol: String): Flow<State> = channelFlow {
+    // Coin detail owns the lifecycle of symbol-specific streams for now.
+    fun maintainCoinDetailStream(symbol: String): Flow<Throwable> = channelFlow {
         val tickerStream = "${symbol.lowercase()}@ticker"
         val klineStream = "${symbol.lowercase()}@kline_$TARGET_INTERVAL"
         val targetStreams = setOf(tickerStream, klineStream)
@@ -66,10 +60,8 @@ class CoinDetailStreamDataSource @Inject constructor(
                     tickerSnapshotDataSource.getTicker(targetSymbol)
                 }.onSuccess { ticker ->
                     tickerTable.upsert(ticker)
-                    trySend(State.Success(ticker))
                 }.onFailure { throwable ->
                     Log.d(TAG, "Ticker snapshot failed: ${throwable.message}")
-                    trySend(State.Error(throwable))
                 }
             }
 
@@ -98,12 +90,12 @@ class CoinDetailStreamDataSource @Inject constructor(
         try {
             launch {
                 merge(
-                marketMessageRouter.streamEvents.map<WsMarketStreamEvent, StreamEvent> {
-                    StreamEvent.Router(it)
-                },
-                subscriptionManager.failures.map<WsSubscriptionFailure, StreamEvent> {
-                    StreamEvent.SubscriptionFailure(it)
-                },
+                    marketMessageRouter.streamEvents.map<WsMarketStreamEvent, StreamEvent> {
+                        StreamEvent.Router(it)
+                    },
+                    subscriptionManager.failures.map<WsSubscriptionFailure, StreamEvent> {
+                        StreamEvent.SubscriptionFailure(it)
+                    },
                 ).collect { streamEvent ->
                     when (streamEvent) {
                         is StreamEvent.Router -> {
@@ -114,7 +106,6 @@ class CoinDetailStreamDataSource @Inject constructor(
                                         val ticker = message.ticker.toCoinTickerDto()
                                         if (ticker.symbol == targetSymbol) {
                                             tickerTable.upsert(ticker)
-                                            trySend(State.Success(ticker))
                                         }
                                     }
 
@@ -134,21 +125,14 @@ class CoinDetailStreamDataSource @Inject constructor(
                                     when (val transportEvent = event.event) {
                                         is BinanceWebSocketClient.Event.Connected -> {
                                             refreshRestData()
-                                            trySend(State.Connected)
                                         }
 
-                                        is BinanceWebSocketClient.Event.Disconnected -> {
-                                            tickerTable.clear()
-                                            klineTable.clear()
-                                            trySend(State.Disconnected)
-                                        }
+                                        is BinanceWebSocketClient.Event.Disconnected -> Unit
 
                                         is BinanceWebSocketClient.Event.Error -> {
                                             if (transportEvent.throwable is WebSocketReconnectExhaustedException) {
-                                                tickerTable.clear()
-                                                klineTable.clear()
+                                                trySend(transportEvent.throwable)
                                             }
-                                            trySend(State.Error(transportEvent.throwable))
                                         }
 
                                         is BinanceWebSocketClient.Event.Message -> Unit
@@ -165,10 +149,8 @@ class CoinDetailStreamDataSource @Inject constructor(
 
                             if (isGlobalFailure || isTargetFailure) {
                                 if (failure.cause is WebSocketReconnectExhaustedException) {
-                                    tickerTable.clear()
-                                    klineTable.clear()
+                                    trySend(failure.cause)
                                 }
-                                trySend(State.Error(failure.cause))
                             }
                         }
                     }
@@ -179,7 +161,6 @@ class CoinDetailStreamDataSource @Inject constructor(
 
             if (sessionManager.isConnected) {
                 refreshRestData()
-                trySend(State.Connected)
             }
 
             awaitCancellation()

--- a/coin-detail/data/src/main/java/io/soma/cryptobook/coindetail/data/repository/CoinDetailRepositoryImpl.kt
+++ b/coin-detail/data/src/main/java/io/soma/cryptobook/coindetail/data/repository/CoinDetailRepositoryImpl.kt
@@ -3,19 +3,19 @@ package io.soma.cryptobook.coindetail.data.repository
 import io.soma.cryptobook.coindetail.data.datasource.CoinDetailStreamDataSource
 import io.soma.cryptobook.coindetail.data.mapper.CoinDetailDomainModelMapper
 import io.soma.cryptobook.coindetail.domain.model.CoinCandleVO
-import io.soma.cryptobook.coindetail.domain.model.CoinDetailVO
 import io.soma.cryptobook.coindetail.domain.model.CoinDetailStreamState
 import io.soma.cryptobook.coindetail.domain.repository.CoinDetailRepository
 import io.soma.cryptobook.core.data.model.CoinKlineDto
 import io.soma.cryptobook.core.data.realtime.kline.WsKlineTable
 import io.soma.cryptobook.core.data.realtime.ticker.WsTickerTable
-import io.soma.cryptobook.core.domain.error.WebSocketReconnectExhaustedException
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
 import javax.inject.Inject
 
 class CoinDetailRepositoryImpl
@@ -26,67 +26,34 @@ constructor(
     private val klineTable: WsKlineTable,
     private val coinDetailDomainModelMapper: CoinDetailDomainModelMapper,
     private val ioDispatcher: CoroutineDispatcher,
-    ) : CoinDetailRepository {
-    override fun observeCoinDetail(symbol: String): Flow<CoinDetailStreamState> = channelFlow {
+ ) : CoinDetailRepository {
+    override fun observeCoinDetail(symbol: String): Flow<CoinDetailStreamState> = flow {
         val targetSymbol = symbol.uppercase()
         val targetInterval = "1d"
-        var latestDetail: CoinDetailVO? = null
-        var latestCandles: List<CoinCandleVO> = emptyList()
 
-        val streamJob = launch {
-            coinDetailStreamDataSource.observeCoinDetail(targetSymbol).collect { state ->
-                when (state) {
-                    is CoinDetailStreamDataSource.State.Error -> {
-                        if (state.throwable is WebSocketReconnectExhaustedException) {
-                            close(state.throwable)
-                        }
-                    }
-
-                    is CoinDetailStreamDataSource.State.Disconnected -> {
-                        Unit
-                    }
-
-                    else -> Unit
-                }
+        val detailStates = combine(
+            tickerTable.observeSymbol(targetSymbol),
+            klineTable.observe(targetSymbol, targetInterval).map { candles ->
+                candles.map { it.toCoinCandleVO() }
+            },
+        ) { ticker, candles ->
+            if (ticker == null) {
+                CoinDetailStreamState.Loading
+            } else {
+                CoinDetailStreamState.Data(
+                    value = coinDetailDomainModelMapper.toDomainModel(ticker),
+                    candles = candles,
+                )
             }
         }
 
-        val tableJob = launch {
-            tickerTable.observeSymbol(targetSymbol).collect { ticker ->
-                if (ticker == null) {
-                    latestDetail = null
-                    send(CoinDetailStreamState.Loading)
-                } else {
-                    latestDetail = coinDetailDomainModelMapper.toDomainModel(ticker)
-                    send(
-                        CoinDetailStreamState.Data(
-                            value = latestDetail!!,
-                            candles = latestCandles,
-                        ),
-                    )
-                }
+        val fatalErrors = flow<CoinDetailStreamState> {
+            coinDetailStreamDataSource.maintainCoinDetailStream(targetSymbol).collect { throwable ->
+                throw throwable
             }
         }
 
-        val klineJob = launch {
-            klineTable.observe(targetSymbol, targetInterval).collect { candles ->
-                latestCandles = candles.map { it.toCoinCandleVO() }
-                latestDetail?.let { detail ->
-                    send(
-                        CoinDetailStreamState.Data(
-                            value = detail,
-                            candles = latestCandles,
-                        ),
-                    )
-                }
-            }
-        }
-
-        awaitClose {
-            streamJob.cancel()
-            tableJob.cancel()
-            klineJob.cancel()
-        }
+        emitAll(merge(detailStates, fatalErrors))
     }.flowOn(ioDispatcher)
 
     private fun CoinKlineDto.toCoinCandleVO(): CoinCandleVO = CoinCandleVO(

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -35,6 +35,8 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.mockk)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 }

--- a/core/network/src/test/java/io/soma/cryptobook/core/network/session/DefaultWsSessionManagerTest.kt
+++ b/core/network/src/test/java/io/soma/cryptobook/core/network/session/DefaultWsSessionManagerTest.kt
@@ -1,0 +1,132 @@
+package io.soma.cryptobook.core.network.session
+
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import io.soma.cryptobook.core.network.BinanceWebSocketClient
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DefaultWsSessionManagerTest {
+
+    @Test
+    fun `acquire called concurrently connects only once`() = runTest {
+        val transportEvents = MutableSharedFlow<BinanceWebSocketClient.Event>(extraBufferCapacity = 16)
+        val connectCalls = AtomicInteger(0)
+        val transport = mockTransport(
+            events = transportEvents,
+            onConnect = { connectCalls.incrementAndGet() },
+        )
+        val manager = createManager(
+            transport = transport,
+            scope = backgroundScope,
+        )
+
+        runConcurrently(times = 8) {
+            manager.acquire()
+        }
+
+        assertEquals(1, connectCalls.get())
+        assertEquals(WsSessionState.Connecting(attempt = 1), manager.state.value)
+        verify(exactly = 1) { transport.connect() }
+    }
+
+    @Test
+    fun `release called concurrently disconnects only once when consumers drain to zero`() = runTest {
+        val transportEvents = MutableSharedFlow<BinanceWebSocketClient.Event>(extraBufferCapacity = 16)
+        val disconnectCalls = AtomicInteger(0)
+        val transport = mockTransport(
+            events = transportEvents,
+            onDisconnect = { disconnectCalls.incrementAndGet() },
+        )
+        val manager = createManager(
+            transport = transport,
+            scope = backgroundScope,
+        )
+
+        repeat(8) {
+            manager.acquire()
+        }
+
+        runConcurrently(times = 8) {
+            manager.release()
+        }
+
+        assertEquals(1, disconnectCalls.get())
+        assertEquals(WsSessionState.Stopped, manager.state.value)
+        verify(exactly = 1) { transport.disconnect() }
+    }
+
+    private fun createManager(
+        transport: BinanceWebSocketClient,
+        scope: CoroutineScope,
+    ): DefaultWsSessionManager = DefaultWsSessionManager(
+        transport = transport,
+        scope = scope,
+        policy = WsSessionPolicy(
+            initialReconnectDelayMs = 1_000L,
+            maxReconnectDelayMs = 30_000L,
+            maxReconnectCount = 5,
+            backoffMultiplier = 2.0,
+            jitterRatio = 0.0,
+        ),
+    )
+
+    private fun mockTransport(
+        events: MutableSharedFlow<BinanceWebSocketClient.Event>,
+        onConnect: () -> Unit = {},
+        onDisconnect: () -> Unit = {},
+    ): BinanceWebSocketClient {
+        val transport = mockk<BinanceWebSocketClient>()
+        every { transport.events } returns events
+        every { transport.isConnected } returns false
+        every { transport.connect() } answers {
+            onConnect()
+            Unit
+        }
+        every { transport.disconnect() } answers {
+            onDisconnect()
+            Unit
+        }
+        every { transport.subscribe(any()) } just runs
+        every { transport.unsubscribe(any()) } just runs
+        return transport
+    }
+
+    private fun runConcurrently(
+        times: Int,
+        action: () -> Unit,
+    ) {
+        val executor = Executors.newFixedThreadPool(times)
+        val ready = CountDownLatch(times)
+        val start = CountDownLatch(1)
+        val done = CountDownLatch(times)
+
+        repeat(times) {
+            executor.execute {
+                ready.countDown()
+                start.await()
+                try {
+                    action()
+                } finally {
+                    done.countDown()
+                }
+            }
+        }
+
+        assertTrue(ready.await(3, TimeUnit.SECONDS))
+        start.countDown()
+        assertTrue(done.await(3, TimeUnit.SECONDS))
+        executor.shutdownNow()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,7 @@ kotlinxSerializationJson = "1.9.0"
 kotlinxAtomicfu = "0.29.0"
 coil = "3.2.0"
 coroutines = "1.10.2"
+mockk = "1.13.11"
 navigation3 = "1.0.0"
 spotless = "6.25.0"
 materialVersion = "1.13.0"
@@ -77,7 +78,9 @@ okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor",
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "kotlinxAtomicfu" }
+mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
 coil-network-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }
 coil-svg = { group = "io.coil-kt.coil3", name = "coil-svg", version.ref = "coil" }

--- a/home/data/src/main/java/io/soma/cryptobook/home/data/datasource/CoinListStreamDataSource.kt
+++ b/home/data/src/main/java/io/soma/cryptobook/home/data/datasource/CoinListStreamDataSource.kt
@@ -24,22 +24,12 @@ class CoinListStreamDataSource @Inject constructor(
     private val tickerTable: WsTickerTable,
     private val marketMessageRouter: WsMarketMessageRouter,
 ) {
-    sealed interface State {
-        data class Success(val tickers: List<CoinTickerDto>) : State
-        data class Error(val throwable: Throwable) : State
-        data object Connected : State
-        data object Disconnected : State
-    }
-
     private val targetStream = "!ticker@arr"
 
-    fun observeCoinList(): Flow<State> = flow {
+    // Home feature owns the lifecycle of the market overview stream for now.
+    fun maintainCoinListStream(): Flow<Throwable> = flow {
         sessionManager.acquire()
         subscriptionManager.retain(setOf(targetStream))
-
-        if (sessionManager.isConnected) {
-            emit(State.Connected)
-        }
 
         try {
             merge(
@@ -58,26 +48,19 @@ class CoinListStreamDataSource @Inject constructor(
                                 if (message is WsMarketMessage.AllTickers) {
                                     val tickers = message.tickers.map { it.toCoinTickerDto() }
                                     tickerTable.upsertAll(tickers)
-                                    emit(State.Success(tickers))
                                 }
                             }
 
                             is WsMarketStreamEvent.Transport -> {
                                 when (val transportEvent = event.event) {
-                                    is BinanceWebSocketClient.Event.Connected -> {
-                                        emit(State.Connected)
-                                    }
+                                    is BinanceWebSocketClient.Event.Connected -> Unit
 
-                                    is BinanceWebSocketClient.Event.Disconnected -> {
-                                        tickerTable.clear()
-                                        emit(State.Disconnected)
-                                    }
+                                    is BinanceWebSocketClient.Event.Disconnected -> Unit
 
                                     is BinanceWebSocketClient.Event.Error -> {
                                         if (transportEvent.throwable is WebSocketReconnectExhaustedException) {
-                                            tickerTable.clear()
+                                            emit(transportEvent.throwable)
                                         }
-                                        emit(State.Error(transportEvent.throwable))
                                     }
 
                                     is BinanceWebSocketClient.Event.Message -> Unit
@@ -94,9 +77,8 @@ class CoinListStreamDataSource @Inject constructor(
 
                         if (isGlobalFailure || isTargetFailure) {
                             if (failure.cause is WebSocketReconnectExhaustedException) {
-                                tickerTable.clear()
+                                emit(failure.cause)
                             }
-                            emit(State.Error(failure.cause))
                         }
                     }
                 }

--- a/home/data/src/main/java/io/soma/cryptobook/home/data/repository/CoinRepositoryImpl.kt
+++ b/home/data/src/main/java/io/soma/cryptobook/home/data/repository/CoinRepositoryImpl.kt
@@ -10,11 +10,13 @@ import io.soma.cryptobook.home.data.datasource.CoinListStreamDataSource
 import io.soma.cryptobook.home.data.mapper.CoinPriceDomainModelMapper
 import io.soma.cryptobook.home.data.model.toCoinPriceVO
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
@@ -31,56 +33,35 @@ constructor(
         coinListRemoteDataSource.getAllTickerPrices().map { it.toCoinPriceVO() }
     }
 
-    override fun observeCoinPrices(): Flow<List<CoinPriceVO>> = channelFlow {
+    override fun observeCoinPrices(): Flow<List<CoinPriceVO>> = flow {
         val initialPrices = LinkedHashMap<String, CoinPriceVO>()
-        var hasInitialEmission = false
-
-        runCatching { getCoinPrices() }
-            .getOrNull()
-            ?.takeIf { it.isNotEmpty() }
-            ?.let { initial ->
-                initial.forEach { initialPrices[it.symbol] = it }
-                send(initial)
-                hasInitialEmission = true
+        val initial = runCatching { getCoinPrices() }
+            .getOrDefault(emptyList())
+            .also { prices ->
+                prices.forEach { initialPrices[it.symbol] = it }
             }
 
-        if (!hasInitialEmission) {
-            send(emptyList())
-        }
+        emit(initial)
 
-        val streamJob = launch {
-            coinListStreamDataSource.observeCoinList().collect { state ->
-                when (state) {
-                    is CoinListStreamDataSource.State.Error -> {
-                        if (state.throwable is WebSocketReconnectExhaustedException) {
-                            close(state.throwable)
-                        }
-                    }
-
-                    is CoinListStreamDataSource.State.Disconnected -> {
-                        send(emptyList())
-                    }
-
-                    else -> Unit
-                }
-            }
-        }
-
-        val tableJob = launch {
-            tickerTable.table.collect { table ->
-                if (table.isEmpty()) return@collect
+        val tableUpdates = tickerTable.table
+            .filter { it.isNotEmpty() }
+            .map { table ->
                 val merged = LinkedHashMap(initialPrices)
                 table.values.forEach { ticker ->
                     merged[ticker.symbol] = coinPriceDomainModelMapper.toDomainModel(ticker)
                 }
-                send(merged.values.toList())
+                merged.values.toList()
+            }
+
+        val fatalErrors = flow<List<CoinPriceVO>> {
+            coinListStreamDataSource.maintainCoinListStream().collect { throwable ->
+                if (throwable is WebSocketReconnectExhaustedException) {
+                    throw throwable
+                }
             }
         }
 
-        awaitClose {
-            streamJob.cancel()
-            tableJob.cancel()
-        }
+        emitAll(merge(tableUpdates, fatalErrors))
     }.flowOn(ioDispatcher)
 
     override suspend fun getCoinInfoList(): List<CoinInfoVO> {


### PR DESCRIPTION
  ## 관련 이슈
  - Closes #55

  ## 사전 점검

  - [ ] `./gradlew spotlessApply` 실행은 별도 PR로 진행 예정

  ## 작업 개요

  `home`과 `coin-detail`의 실시간 데이터 전달 구조를 정리해, 각 레이어에서 `collect -> emit/send`를 반복하던 흐름을 줄이고 `WS Table` 기반 상태 소비 구조로 맞췄습니다.

  ## 상세 내용

  ### 1️⃣ UI/UX 변경
  - 직접적인 UI 변경은 없음
  - 연결 끊김 시 마지막 데이터 유지 방향으로 구조를 정리

  ### 2️⃣ 로직 및 아키텍처

  - **기존 방식:** DataSource가 table 적재와 화면용 상태 재방출을 함께 수행하고, Repository가 이를 다시 collect/send
  - **변경 방식:** DataSource는 runner + table writer 역할로 축소하고, Repository는 table을 직접 읽어 상태를 조합

  | 구분 | AS-IS (기존) | TO-BE (변경) |
  | :---: | :---: | :---: |
  | `home` | DataSource 상태 emit + Repository 재조합 | `WsTickerTable` 직접 소비 |
  | `coin-detail` | DataSource 상태 emit + Repository `channelFlow` 재전송 | DataSource는 orchestration/table update만, Repository는 `tickerTable + klineTable` 조합 |
  | disconnect 처리 | 빈 상태/clear 경로 존재 | 마지막 데이터 유지 중심 |

  ### 3️⃣ 리팩토링
  - `home`
    - DataSource의 화면용 payload 재방출 제거
    - Repository를 `tickerTable.table` 기반 변환으로 정리
  - `coin-detail`
    - DataSource는 `channelFlow`를 유지하되 병렬 orchestration 전용으로 축소
    - Repository의 `channelFlow + launch + send` 제거
    - `tickerTable.observeSymbol()` + `klineTable.observe()` 기반 상태 조합으로 변경
    - disconnect/error 시 singleton table 전체 clear 제거
  - 후속 app coordinator 방향은 문서로만 분리

  ## 리뷰어 집중 포인트(참고 사항)
  - `channelFlow`를 전면 제거한 것이 아니라, 병렬 producer가 필요한 DataSource에만 남겼습니다.
  - `coin-detail`의 전역 table clear 제거가 현재 UX/상태 정책과 잘 맞는지 확인 부탁드립니다.

  ## 후속 작업
  - [ ] 초기 REST snapshot의 table 통합 검토
  - [ ] app coordinator 승격 여부 검토
  - [ ] data/repository 단위 테스트 보강
