### PR TITLE
refactor(data): Binance spot market 기준으로 API/WS 경로 통합

### DIFF
--- a/app/src/main/java/io/soma/cryptobook/di/BinanceSpotMarketRemote.kt
+++ b/app/src/main/java/io/soma/cryptobook/di/BinanceSpotMarketRemote.kt
@@ -1,8 +1,8 @@
 package io.soma.cryptobook.di
 
-import io.soma.cryptobook.coindetail.data.network.BinanceFuturesKlineClient
-import io.soma.cryptobook.coindetail.data.model.BinanceFuturesTickerDto
-import io.soma.cryptobook.coindetail.data.network.BinanceFuturesTickerClient
+import io.soma.cryptobook.coindetail.data.model.BinanceSpotTickerDto
+import io.soma.cryptobook.coindetail.data.network.BinanceSpotKlineClient
+import io.soma.cryptobook.coindetail.data.network.BinanceSpotTickerClient
 import io.soma.cryptobook.core.network.base.BaseDataSource
 import kotlinx.serialization.json.JsonElement
 import retrofit2.Response
@@ -10,8 +10,8 @@ import retrofit2.http.GET
 import retrofit2.http.Query
 import javax.inject.Inject
 
-interface BinanceFuturesApiService {
-    @GET("fapi/v1/klines")
+interface BinanceSpotApiService {
+    @GET("api/v3/klines")
     suspend fun getKlines(
         @Query("symbol") symbol: String,
         @Query("interval") interval: String,
@@ -20,15 +20,15 @@ interface BinanceFuturesApiService {
         @Query("limit") limit: Int,
     ): Response<List<List<JsonElement>>>
 
-    @GET("fapi/v1/ticker/24hr")
+    @GET("api/v3/ticker/24hr")
     suspend fun getTicker(
         @Query("symbol") symbol: String,
-    ): Response<BinanceFuturesTickerDto>
+    ): Response<BinanceSpotTickerDto>
 }
 
-class DefaultBinanceFuturesKlineClient @Inject constructor(
-    private val apiService: BinanceFuturesApiService,
-) : BaseDataSource(), BinanceFuturesKlineClient {
+class DefaultBinanceSpotKlineClient @Inject constructor(
+    private val apiService: BinanceSpotApiService,
+) : BaseDataSource(), BinanceSpotKlineClient {
     override suspend fun getKlines(
         symbol: String,
         interval: String,
@@ -46,10 +46,10 @@ class DefaultBinanceFuturesKlineClient @Inject constructor(
     )
 }
 
-class DefaultBinanceFuturesTickerClient @Inject constructor(
-    private val apiService: BinanceFuturesApiService,
-) : BaseDataSource(), BinanceFuturesTickerClient {
-    override suspend fun getTicker(symbol: String): BinanceFuturesTickerDto = checkResponse(
+class DefaultBinanceSpotTickerClient @Inject constructor(
+    private val apiService: BinanceSpotApiService,
+) : BaseDataSource(), BinanceSpotTickerClient {
+    override suspend fun getTicker(symbol: String): BinanceSpotTickerDto = checkResponse(
         apiService.getTicker(symbol = symbol),
     )
 }

--- a/app/src/main/java/io/soma/cryptobook/di/BinanceSpotMarketRemote.kt
+++ b/app/src/main/java/io/soma/cryptobook/di/BinanceSpotMarketRemote.kt
@@ -21,9 +21,7 @@ interface BinanceSpotApiService {
     ): Response<List<List<JsonElement>>>
 
     @GET("api/v3/ticker/24hr")
-    suspend fun getTicker(
-        @Query("symbol") symbol: String,
-    ): Response<BinanceSpotTickerDto>
+    suspend fun getTicker(@Query("symbol") symbol: String): Response<BinanceSpotTickerDto>
 }
 
 class DefaultBinanceSpotKlineClient @Inject constructor(

--- a/app/src/main/java/io/soma/cryptobook/di/NetworkModule.kt
+++ b/app/src/main/java/io/soma/cryptobook/di/NetworkModule.kt
@@ -4,8 +4,8 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import io.soma.cryptobook.coindetail.data.network.BinanceFuturesKlineClient
-import io.soma.cryptobook.coindetail.data.network.BinanceFuturesTickerClient
+import io.soma.cryptobook.coindetail.data.network.BinanceSpotKlineClient
+import io.soma.cryptobook.coindetail.data.network.BinanceSpotTickerClient
 import io.soma.cryptobook.core.data.network.ExchangeApiService
 import io.soma.cryptobook.core.network.BinanceWebSocketClient
 import io.soma.cryptobook.core.network.market.DefaultWsMarketMessageRouter
@@ -35,10 +35,6 @@ annotation class BinanceNetwork
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
-annotation class BinanceFuturesNetwork
-
-@Qualifier
-@Retention(AnnotationRetention.BINARY)
 annotation class CryptoBookNetwork
 
 @Qualifier
@@ -49,7 +45,6 @@ annotation class KoreaEximNetwork
 @InstallIn(SingletonComponent::class)
 object NetworkModule {
     private const val BINANCE_BASE_URL = "https://api.binance.com/"
-    private const val BINANCE_FUTURES_BASE_URL = "https://fapi.binance.com/"
     private const val CRYPTOBOOK_BASE_URL = "https://cryptobook.soma.io/"
     private const val KOREA_EXIM_BASE_URL = "https://oapi.koreaexim.go.kr/"
 
@@ -87,41 +82,26 @@ object NetworkModule {
 
     @Provides
     @Singleton
-    fun provideBinanceApiService(@BinanceFuturesNetwork retrofit: Retrofit): BinanceApiService =
+    fun provideBinanceApiService(@BinanceNetwork retrofit: Retrofit): BinanceApiService =
         retrofit.create(BinanceApiService::class.java)
 
     @Provides
     @Singleton
-    @BinanceFuturesNetwork
-    fun provideBinanceFuturesRetrofit(
-        @BinanceNetwork okHttpClient: OkHttpClient,
-        json: Json,
-    ): Retrofit {
-        val contentType = "application/json".toMediaType()
-        return Retrofit.Builder()
-            .client(okHttpClient)
-            .baseUrl(BINANCE_FUTURES_BASE_URL)
-            .addConverterFactory(json.asConverterFactory(contentType))
-            .build()
-    }
+    fun provideBinanceSpotApiService(
+        @BinanceNetwork retrofit: Retrofit,
+    ): BinanceSpotApiService = retrofit.create(BinanceSpotApiService::class.java)
 
     @Provides
     @Singleton
-    fun provideBinanceFuturesApiService(
-        @BinanceFuturesNetwork retrofit: Retrofit,
-    ): BinanceFuturesApiService = retrofit.create(BinanceFuturesApiService::class.java)
+    fun provideBinanceSpotKlineClient(
+        apiService: BinanceSpotApiService,
+    ): BinanceSpotKlineClient = DefaultBinanceSpotKlineClient(apiService)
 
     @Provides
     @Singleton
-    fun provideBinanceFuturesKlineClient(
-        apiService: BinanceFuturesApiService,
-    ): BinanceFuturesKlineClient = DefaultBinanceFuturesKlineClient(apiService)
-
-    @Provides
-    @Singleton
-    fun provideBinanceFuturesTickerClient(
-        apiService: BinanceFuturesApiService,
-    ): BinanceFuturesTickerClient = DefaultBinanceFuturesTickerClient(apiService)
+    fun provideBinanceSpotTickerClient(
+        apiService: BinanceSpotApiService,
+    ): BinanceSpotTickerClient = DefaultBinanceSpotTickerClient(apiService)
 
     @Provides
     @Singleton

--- a/app/src/main/java/io/soma/cryptobook/di/NetworkModule.kt
+++ b/app/src/main/java/io/soma/cryptobook/di/NetworkModule.kt
@@ -87,15 +87,13 @@ object NetworkModule {
 
     @Provides
     @Singleton
-    fun provideBinanceSpotApiService(
-        @BinanceNetwork retrofit: Retrofit,
-    ): BinanceSpotApiService = retrofit.create(BinanceSpotApiService::class.java)
+    fun provideBinanceSpotApiService(@BinanceNetwork retrofit: Retrofit): BinanceSpotApiService =
+        retrofit.create(BinanceSpotApiService::class.java)
 
     @Provides
     @Singleton
-    fun provideBinanceSpotKlineClient(
-        apiService: BinanceSpotApiService,
-    ): BinanceSpotKlineClient = DefaultBinanceSpotKlineClient(apiService)
+    fun provideBinanceSpotKlineClient(apiService: BinanceSpotApiService): BinanceSpotKlineClient =
+        DefaultBinanceSpotKlineClient(apiService)
 
     @Provides
     @Singleton
@@ -145,7 +143,8 @@ object NetworkModule {
 
     @Provides
     @Singleton
-    fun provideWsMarketMessageParser(json: Json): WsMarketMessageParser = WsMarketMessageParser(json)
+    fun provideWsMarketMessageParser(json: Json): WsMarketMessageParser =
+        WsMarketMessageParser(json)
 
     @Provides
     @Singleton

--- a/coin-detail/data/src/main/java/io/soma/cryptobook/coindetail/data/datasource/CoinDetailKlineBackfillDataSource.kt
+++ b/coin-detail/data/src/main/java/io/soma/cryptobook/coindetail/data/datasource/CoinDetailKlineBackfillDataSource.kt
@@ -82,10 +82,7 @@ class CoinDetailKlineBackfillDataSource @Inject constructor(
             .distinctBy(CoinKlineDto::openTime)
     }
 
-    private fun List<JsonElement>.toCoinKlineDto(
-        symbol: String,
-        interval: String,
-    ): CoinKlineDto? {
+    private fun List<JsonElement>.toCoinKlineDto(symbol: String, interval: String): CoinKlineDto? {
         if (size < 7) return null
         val openTime = this[0].jsonPrimitive.longOrNull ?: return null
         val closeTime = this[6].jsonPrimitive.longOrNull ?: return null

--- a/coin-detail/data/src/main/java/io/soma/cryptobook/coindetail/data/datasource/CoinDetailKlineBackfillDataSource.kt
+++ b/coin-detail/data/src/main/java/io/soma/cryptobook/coindetail/data/datasource/CoinDetailKlineBackfillDataSource.kt
@@ -1,6 +1,6 @@
 package io.soma.cryptobook.coindetail.data.datasource
 
-import io.soma.cryptobook.coindetail.data.network.BinanceFuturesKlineClient
+import io.soma.cryptobook.coindetail.data.network.BinanceSpotKlineClient
 import io.soma.cryptobook.core.data.model.CoinKlineDto
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.contentOrNull
@@ -9,11 +9,11 @@ import kotlinx.serialization.json.longOrNull
 import javax.inject.Inject
 
 class CoinDetailKlineBackfillDataSource @Inject constructor(
-    private val klineClient: BinanceFuturesKlineClient,
+    private val klineClient: BinanceSpotKlineClient,
 ) {
     private companion object {
         private const val EARLIEST_START_TIME_MS = 0L
-        private const val MAX_PAGE_SIZE = 1500
+        private const val MAX_PAGE_SIZE = 1000
     }
 
     suspend fun getKlines(

--- a/coin-detail/data/src/main/java/io/soma/cryptobook/coindetail/data/datasource/CoinDetailStreamDataSource.kt
+++ b/coin-detail/data/src/main/java/io/soma/cryptobook/coindetail/data/datasource/CoinDetailStreamDataSource.kt
@@ -39,7 +39,7 @@ class CoinDetailStreamDataSource @Inject constructor(
     private companion object {
         private const val TAG = "CoinDetailStream"
         private const val TARGET_INTERVAL = "1d"
-        private const val KLINE_BACKFILL_PAGE_LIMIT = 1500
+        private const val KLINE_BACKFILL_PAGE_LIMIT = 1000
     }
 
     // Coin detail owns the lifecycle of symbol-specific streams for now.

--- a/coin-detail/data/src/main/java/io/soma/cryptobook/coindetail/data/datasource/CoinDetailStreamDataSource.kt
+++ b/coin-detail/data/src/main/java/io/soma/cryptobook/coindetail/data/datasource/CoinDetailStreamDataSource.kt
@@ -111,7 +111,10 @@ class CoinDetailStreamDataSource @Inject constructor(
 
                                     if (message is WsMarketMessage.SymbolKline) {
                                         val candle = message.klineEvent.toCoinKlineDto()
-                                        if (candle.symbol == targetSymbol && candle.interval == TARGET_INTERVAL) {
+                                        if (
+                                            candle.symbol == targetSymbol &&
+                                            candle.interval == TARGET_INTERVAL
+                                        ) {
                                             klineTable.upsert(
                                                 symbol = targetSymbol,
                                                 interval = TARGET_INTERVAL,
@@ -130,7 +133,10 @@ class CoinDetailStreamDataSource @Inject constructor(
                                         is BinanceWebSocketClient.Event.Disconnected -> Unit
 
                                         is BinanceWebSocketClient.Event.Error -> {
-                                            if (transportEvent.throwable is WebSocketReconnectExhaustedException) {
+                                            val reconnectExhausted =
+                                                transportEvent.throwable is
+                                                    WebSocketReconnectExhaustedException
+                                            if (reconnectExhausted) {
                                                 trySend(transportEvent.throwable)
                                             }
                                         }

--- a/coin-detail/data/src/main/java/io/soma/cryptobook/coindetail/data/datasource/CoinDetailTickerSnapshotDataSource.kt
+++ b/coin-detail/data/src/main/java/io/soma/cryptobook/coindetail/data/datasource/CoinDetailTickerSnapshotDataSource.kt
@@ -1,12 +1,12 @@
 package io.soma.cryptobook.coindetail.data.datasource
 
 import io.soma.cryptobook.coindetail.data.model.toCoinTickerDto
-import io.soma.cryptobook.coindetail.data.network.BinanceFuturesTickerClient
+import io.soma.cryptobook.coindetail.data.network.BinanceSpotTickerClient
 import io.soma.cryptobook.core.data.model.CoinTickerDto
 import javax.inject.Inject
 
 class CoinDetailTickerSnapshotDataSource @Inject constructor(
-    private val tickerClient: BinanceFuturesTickerClient,
+    private val tickerClient: BinanceSpotTickerClient,
 ) {
     suspend fun getTicker(symbol: String): CoinTickerDto = tickerClient.getTicker(
         symbol = symbol.uppercase(),

--- a/coin-detail/data/src/main/java/io/soma/cryptobook/coindetail/data/model/BinanceSpotTickerDto.kt
+++ b/coin-detail/data/src/main/java/io/soma/cryptobook/coindetail/data/model/BinanceSpotTickerDto.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class BinanceFuturesTickerDto(
+data class BinanceSpotTickerDto(
     @SerialName("symbol")
     val symbol: String,
     @SerialName("lastPrice")
@@ -24,7 +24,7 @@ data class BinanceFuturesTickerDto(
     val openPrice: String,
 )
 
-fun BinanceFuturesTickerDto.toCoinTickerDto(): CoinTickerDto = CoinTickerDto(
+fun BinanceSpotTickerDto.toCoinTickerDto(): CoinTickerDto = CoinTickerDto(
     symbol = symbol.uppercase(),
     lastPrice = lastPrice,
     priceChangePercent = priceChangePercent,

--- a/coin-detail/data/src/main/java/io/soma/cryptobook/coindetail/data/network/BinanceSpotMarketClient.kt
+++ b/coin-detail/data/src/main/java/io/soma/cryptobook/coindetail/data/network/BinanceSpotMarketClient.kt
@@ -1,9 +1,9 @@
 package io.soma.cryptobook.coindetail.data.network
 
-import io.soma.cryptobook.coindetail.data.model.BinanceFuturesTickerDto
+import io.soma.cryptobook.coindetail.data.model.BinanceSpotTickerDto
 import kotlinx.serialization.json.JsonElement
 
-interface BinanceFuturesKlineClient {
+interface BinanceSpotKlineClient {
     suspend fun getKlines(
         symbol: String,
         interval: String,
@@ -13,6 +13,6 @@ interface BinanceFuturesKlineClient {
     ): List<List<JsonElement>>
 }
 
-interface BinanceFuturesTickerClient {
-    suspend fun getTicker(symbol: String): BinanceFuturesTickerDto
+interface BinanceSpotTickerClient {
+    suspend fun getTicker(symbol: String): BinanceSpotTickerDto
 }

--- a/coin-detail/data/src/main/java/io/soma/cryptobook/coindetail/data/repository/CoinDetailRepositoryImpl.kt
+++ b/coin-detail/data/src/main/java/io/soma/cryptobook/coindetail/data/repository/CoinDetailRepositoryImpl.kt
@@ -26,7 +26,7 @@ constructor(
     private val klineTable: WsKlineTable,
     private val coinDetailDomainModelMapper: CoinDetailDomainModelMapper,
     private val ioDispatcher: CoroutineDispatcher,
- ) : CoinDetailRepository {
+) : CoinDetailRepository {
     override fun observeCoinDetail(symbol: String): Flow<CoinDetailStreamState> = flow {
         val targetSymbol = symbol.uppercase()
         val targetInterval = "1d"

--- a/coin-detail/presentation/src/main/java/io/soma/cryptobook/coindetail/presentation/CoinDetailScreen.kt
+++ b/coin-detail/presentation/src/main/java/io/soma/cryptobook/coindetail/presentation/CoinDetailScreen.kt
@@ -3,8 +3,8 @@ package io.soma.cryptobook.coindetail.presentation
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CircularProgressIndicator
@@ -22,8 +22,8 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import io.soma.cryptobook.coindetail.presentation.component.MetricCardGridContainer
 import io.soma.cryptobook.coindetail.presentation.component.CoinCandlestickChart
+import io.soma.cryptobook.coindetail.presentation.component.MetricCardGridContainer
 import io.soma.cryptobook.coindetail.presentation.component.PriceChange
 import io.soma.cryptobook.coindetail.presentation.component.PriceChangeType
 import io.soma.cryptobook.core.designsystem.theme.ScreenBackground

--- a/coin-detail/presentation/src/main/java/io/soma/cryptobook/coindetail/presentation/component/CoinCandlestickChart.kt
+++ b/coin-detail/presentation/src/main/java/io/soma/cryptobook/coindetail/presentation/component/CoinCandlestickChart.kt
@@ -9,8 +9,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import io.soma.cryptobook.coindetail.presentation.CandleUiModel
 import com.patrykandpatrick.vico.compose.cartesian.AutoScrollCondition
 import com.patrykandpatrick.vico.compose.cartesian.CartesianChartHost
 import com.patrykandpatrick.vico.compose.cartesian.Scroll
@@ -25,14 +23,12 @@ import com.patrykandpatrick.vico.compose.cartesian.layer.rememberCandlestickCart
 import com.patrykandpatrick.vico.compose.cartesian.rememberCartesianChart
 import com.patrykandpatrick.vico.compose.cartesian.rememberVicoScrollState
 import com.patrykandpatrick.vico.compose.cartesian.rememberVicoZoomState
+import io.soma.cryptobook.coindetail.presentation.CandleUiModel
 
 private const val START_AXIS_LABEL_COUNT = 5
 
 @Composable
-fun CoinCandlestickChart(
-    candles: List<CandleUiModel>,
-    modifier: Modifier = Modifier,
-) {
+fun CoinCandlestickChart(candles: List<CandleUiModel>, modifier: Modifier = Modifier) {
     val modelProducer = remember { CartesianChartModelProducer() }
     val scrollState = rememberVicoScrollState(
         initialScroll = Scroll.Absolute.End,

--- a/coin-detail/presentation/src/main/java/io/soma/cryptobook/coindetail/presentation/component/CoinCandlestickChartSupport.kt
+++ b/coin-detail/presentation/src/main/java/io/soma/cryptobook/coindetail/presentation/component/CoinCandlestickChartSupport.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import com.patrykandpatrick.vico.compose.cartesian.VicoScrollState
 import com.patrykandpatrick.vico.compose.cartesian.VicoZoomState
-import com.patrykandpatrick.vico.compose.cartesian.axis.Axis
 import com.patrykandpatrick.vico.compose.cartesian.data.CartesianLayerRangeProvider
 import com.patrykandpatrick.vico.compose.cartesian.data.CartesianValueFormatter
 import com.patrykandpatrick.vico.compose.common.data.ExtraStore
@@ -173,7 +172,7 @@ private fun List<CandleUiModel>.visibleSlice(
     val fullRangeLength = lastIndex.toDouble() + edgePaddingInX * 2.0
     val visibleRangeLength = (
         fullRangeLength - maxScrollPx.toDouble() / scaledXSpacingPx
-    ).coerceIn(edgePaddingInX.toDouble(), fullRangeLength)
+        ).coerceIn(edgePaddingInX.toDouble(), fullRangeLength)
     val visibleRangeStart = fullRangeStart + scrollPx.toDouble() / scaledXSpacingPx
     val visibleRangeEnd = visibleRangeStart + visibleRangeLength
 

--- a/core/network/src/main/java/io/soma/cryptobook/core/network/BinanceWebSocketClient.kt
+++ b/core/network/src/main/java/io/soma/cryptobook/core/network/BinanceWebSocketClient.kt
@@ -39,7 +39,7 @@ class BinanceWebSocketClient @Inject constructor(
 
     companion object {
         private const val TAG = "BinanceWS"
-        private const val BASE_URL = "wss://fstream.binance.com/ws"
+        private const val BASE_URL = "wss://stream.binance.com:9443/ws"
     }
 
     private var webSocket: WebSocket? = null

--- a/core/network/src/main/java/io/soma/cryptobook/core/network/market/WsMarketDebugLogger.kt
+++ b/core/network/src/main/java/io/soma/cryptobook/core/network/market/WsMarketDebugLogger.kt
@@ -10,7 +10,7 @@ internal class WsMarketDebugLogger(
 ) {
     companion object {
         private const val TAG = "WsMarketDebug"
-        private const val ALL_TICKERS_STREAM = "!ticker@arr"
+        private const val ALL_MINI_TICKERS_STREAM = "!miniTicker@arr"
     }
 
     private val sequence = AtomicLong(0L)
@@ -36,7 +36,7 @@ internal class WsMarketDebugLogger(
         if (!shouldLog(seq)) return
 
         val type = when (message) {
-            is WsMarketMessage.AllTickers -> "AllTickers"
+            is WsMarketMessage.AllMiniTickers -> "AllMiniTickers"
             is WsMarketMessage.SymbolTicker -> "SymbolTicker"
             is WsMarketMessage.SymbolKline -> "SymbolKline"
             is WsMarketMessage.Ignored -> "Ignored"
@@ -55,7 +55,7 @@ internal class WsMarketDebugLogger(
     }
 
     private fun streamOf(message: WsMarketMessage): String = when (message) {
-        is WsMarketMessage.AllTickers -> ALL_TICKERS_STREAM
+        is WsMarketMessage.AllMiniTickers -> ALL_MINI_TICKERS_STREAM
         is WsMarketMessage.SymbolTicker -> "${message.ticker.symbol.lowercase()}@ticker"
         is WsMarketMessage.SymbolKline -> {
             val symbol = message.klineEvent.symbol.lowercase()
@@ -67,7 +67,7 @@ internal class WsMarketDebugLogger(
     }
 
     private fun summaryOf(message: WsMarketMessage): String = when (message) {
-        is WsMarketMessage.AllTickers -> {
+        is WsMarketMessage.AllMiniTickers -> {
             val topSymbols = message.tickers
                 .take(3)
                 .joinToString(separator = ",") { it.symbol }

--- a/core/network/src/main/java/io/soma/cryptobook/core/network/market/WsMarketDebugLogger.kt
+++ b/core/network/src/main/java/io/soma/cryptobook/core/network/market/WsMarketDebugLogger.kt
@@ -44,7 +44,9 @@ internal class WsMarketDebugLogger(
 
         Log.d(
             TAG,
-            "[WS_PARSED] seq=$seq type=$type stream=${streamOf(message)} summary=${summaryOf(message)}",
+            "[WS_PARSED] seq=$seq type=$type stream=${streamOf(
+                message,
+            )} summary=${summaryOf(message)}",
         )
     }
 
@@ -60,7 +62,7 @@ internal class WsMarketDebugLogger(
         is WsMarketMessage.SymbolKline -> {
             val symbol = message.klineEvent.symbol.lowercase()
             val interval = message.klineEvent.kline.interval.lowercase()
-            "${symbol}@kline_$interval"
+            "$symbol@kline_$interval"
         }
 
         is WsMarketMessage.Ignored -> "-"
@@ -77,13 +79,16 @@ internal class WsMarketDebugLogger(
 
         is WsMarketMessage.SymbolTicker -> {
             val ticker = message.ticker
-            "symbol=${ticker.symbol} lastPrice=${ticker.lastPrice} changePercent=${ticker.priceChangePercent}"
+            "symbol=${ticker.symbol} lastPrice=${ticker.lastPrice} " +
+                "changePercent=${ticker.priceChangePercent}"
         }
 
         is WsMarketMessage.SymbolKline -> {
             val event = message.klineEvent
             val kline = event.kline
-            "symbol=${event.symbol} interval=${kline.interval} openTime=${kline.openTime} closeTime=${kline.closeTime} isClosed=${kline.isClosed}"
+            "symbol=${event.symbol} interval=${kline.interval} " +
+                "openTime=${kline.openTime} closeTime=${kline.closeTime} " +
+                "isClosed=${kline.isClosed}"
         }
 
         is WsMarketMessage.Ignored -> "ignored"

--- a/core/network/src/main/java/io/soma/cryptobook/core/network/market/WsMarketMessage.kt
+++ b/core/network/src/main/java/io/soma/cryptobook/core/network/market/WsMarketMessage.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 sealed interface WsMarketMessage {
-    data class AllTickers(val tickers: List<WsTickerPayload>) : WsMarketMessage
+    data class AllMiniTickers(val tickers: List<WsMiniTickerPayload>) : WsMarketMessage
     data class SymbolTicker(val ticker: WsTickerPayload) : WsMarketMessage
     data class SymbolKline(val klineEvent: WsKlineEventPayload) : WsMarketMessage
     data object Ignored : WsMarketMessage
@@ -21,6 +21,18 @@ data class WsTickerPayload(
     @SerialName("h") val highPrice: String,
     @SerialName("q") val quoteAssetVolume: String,
     @SerialName("o") val openPrice: String,
+)
+
+@Serializable
+data class WsMiniTickerPayload(
+    @SerialName("e") val eventType: String? = null,
+    @SerialName("s") val symbol: String,
+    @SerialName("c") val lastPrice: String,
+    @SerialName("o") val openPrice: String,
+    @SerialName("h") val highPrice: String,
+    @SerialName("l") val lowPrice: String,
+    @SerialName("v") val volume: String,
+    @SerialName("q") val quoteAssetVolume: String,
 )
 
 @Serializable

--- a/core/network/src/main/java/io/soma/cryptobook/core/network/market/WsMarketMessageParser.kt
+++ b/core/network/src/main/java/io/soma/cryptobook/core/network/market/WsMarketMessageParser.kt
@@ -1,10 +1,10 @@
 package io.soma.cryptobook.core.network.market
 
 import android.util.Log
-import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.decodeFromJsonElement
-import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import javax.inject.Inject

--- a/core/network/src/main/java/io/soma/cryptobook/core/network/market/WsMarketMessageParser.kt
+++ b/core/network/src/main/java/io/soma/cryptobook/core/network/market/WsMarketMessageParser.kt
@@ -1,6 +1,7 @@
 package io.soma.cryptobook.core.network.market
 
 import android.util.Log
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.Json
@@ -14,6 +15,7 @@ class WsMarketMessageParser @Inject constructor(
     companion object {
         private const val TAG = "WsMarketMessageParser"
         private const val EVENT_24HR_TICKER = "24hrTicker"
+        private const val EVENT_24HR_MINI_TICKER = "24hrMiniTicker"
         private const val EVENT_KLINE = "kline"
     }
 
@@ -23,7 +25,7 @@ class WsMarketMessageParser @Inject constructor(
         if (isControlAckMessage(message)) return WsMarketMessage.Ignored
 
         return when {
-            message.startsWith("[") -> parseAllTickers(message)
+            message.startsWith("[") -> parseArrayMessage(message)
             message.startsWith("{") -> parseSymbolMessage(message)
             else -> WsMarketMessage.Ignored
         }
@@ -41,13 +43,24 @@ class WsMarketMessageParser @Inject constructor(
             jsonObject.containsKey("msg")
     }
 
-    private fun parseAllTickers(message: String): WsMarketMessage = runCatching {
-        val tickers = json.decodeFromString<List<WsTickerPayload>>(message)
-        val payload = tickers.filter { it.eventType == EVENT_24HR_TICKER }
-        if (payload.isEmpty()) {
-            WsMarketMessage.Ignored
-        } else {
-            WsMarketMessage.AllTickers(payload)
+    private fun parseArrayMessage(message: String): WsMarketMessage = runCatching {
+        val element = json.parseToJsonElement(message)
+        val payload = element.jsonArray
+        val eventType = payload.firstOrNull()
+            ?.jsonObject
+            ?.get("e")
+            ?.jsonPrimitive
+            ?.contentOrNull
+
+        when (eventType) {
+            EVENT_24HR_MINI_TICKER -> {
+                val tickers = json.decodeFromJsonElement<List<WsMiniTickerPayload>>(element)
+                WsMarketMessage.AllMiniTickers(tickers)
+            }
+
+            else -> {
+                WsMarketMessage.Ignored
+            }
         }
     }.getOrElse { throwable ->
         Log.d(TAG, "[WS_PARSE] action=ignored kind=array reason=${throwable.message}")

--- a/core/network/src/main/java/io/soma/cryptobook/core/network/session/DefaultWsSessionManager.kt
+++ b/core/network/src/main/java/io/soma/cryptobook/core/network/session/DefaultWsSessionManager.kt
@@ -93,7 +93,6 @@ class DefaultWsSessionManager @Inject constructor(
             }
 
             is BinanceWebSocketClient.Event.Message -> {
-
             }
 
             is BinanceWebSocketClient.Event.Disconnected -> {
@@ -151,7 +150,9 @@ class DefaultWsSessionManager @Inject constructor(
         val attempt = reconnectAttempt.incrementAndGet()
         if (attempt > policy.maxReconnectCount) {
             _state.value = WsSessionState.Exhausted(attempt = attempt, cause = cause)
-            _events.tryEmit(BinanceWebSocketClient.Event.Error(WebSocketReconnectExhaustedException()))
+            _events.tryEmit(
+                BinanceWebSocketClient.Event.Error(WebSocketReconnectExhaustedException()),
+            )
             return
         }
 

--- a/core/network/src/main/java/io/soma/cryptobook/core/network/subscription/DefaultWsSubscriptionManager.kt
+++ b/core/network/src/main/java/io/soma/cryptobook/core/network/subscription/DefaultWsSubscriptionManager.kt
@@ -393,13 +393,13 @@ class DefaultWsSubscriptionManager @Inject constructor(
         val array = result as? JsonArray ?: return emptySet()
         return array.mapNotNull { element ->
             val primitive = element as? JsonPrimitive ?: return@mapNotNull null
-            primitive.contentOrNull?.trim()?.lowercase()?.takeIf { it.isNotEmpty() }
+            primitive.contentOrNull?.trim()?.takeIf { it.isNotEmpty() }
         }.toSet()
     }
 
     private fun normalizeStreams(streams: Set<String>): Set<String> = streams
         .asSequence()
-        .map { it.trim().lowercase() }
+        .map { it.trim() }
         .filter { it.isNotEmpty() }
         .toSet()
 

--- a/core/network/src/main/java/io/soma/cryptobook/core/network/subscription/DefaultWsSubscriptionManager.kt
+++ b/core/network/src/main/java/io/soma/cryptobook/core/network/subscription/DefaultWsSubscriptionManager.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex

--- a/core/network/src/main/java/io/soma/cryptobook/core/network/subscription/DefaultWsSubscriptionManager.kt
+++ b/core/network/src/main/java/io/soma/cryptobook/core/network/subscription/DefaultWsSubscriptionManager.kt
@@ -335,7 +335,9 @@ class DefaultWsSubscriptionManager @Inject constructor(
 
             is ControlMessage.Result -> {
                 if (pending.method == WsSubscriptionMethod.ListSubscriptions) {
-                    pending.deferred.complete(RequestAck.ListSuccess(parseStreamsFromResult(control.result)))
+                    pending.deferred.complete(
+                        RequestAck.ListSuccess(parseStreamsFromResult(control.result)),
+                    )
                 } else {
                     pending.deferred.complete(RequestAck.Success)
                 }
@@ -429,8 +431,10 @@ class DefaultWsSubscriptionManager @Inject constructor(
 
         Log.d(
             TAG,
-            "[WS_SUB] action=$action method=${method.wireValue} streams=${streams.sorted()}$attemptPart$causePart " +
-                "desired=${desired.size}:$desired confirmed=${confirmed.size}:$confirmed pending=${pending.size}:$pending",
+            "[WS_SUB] action=$action method=${method.wireValue} " +
+                "streams=${streams.sorted()}$attemptPart$causePart " +
+                "desired=${desired.size}:$desired confirmed=${confirmed.size}:$confirmed " +
+                "pending=${pending.size}:$pending",
         )
     }
 
@@ -473,5 +477,4 @@ class DefaultWsSubscriptionManager @Inject constructor(
         code: Int?,
         msg: String?,
     ) : Exception("ACK error for ${method.wireValue} (id=$id, code=$code, msg=$msg)")
-
 }

--- a/core/network/src/test/java/io/soma/cryptobook/core/network/market/WsMarketMessageParserTest.kt
+++ b/core/network/src/test/java/io/soma/cryptobook/core/network/market/WsMarketMessageParserTest.kt
@@ -1,0 +1,50 @@
+package io.soma.cryptobook.core.network.market
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WsMarketMessageParserTest {
+    private val parser = WsMarketMessageParser(
+        json = Json {
+            ignoreUnknownKeys = true
+        },
+    )
+
+    @Test
+    fun `parse returns all mini tickers for mini ticker array payload`() {
+        val raw = """
+            [
+              {
+                "e":"24hrMiniTicker",
+                "s":"BTCUSDT",
+                "c":"102.5",
+                "o":"100.0",
+                "h":"103.0",
+                "l":"99.0",
+                "v":"10.0",
+                "q":"1025.0"
+              },
+              {
+                "e":"24hrMiniTicker",
+                "s":"ETHUSDT",
+                "c":"205.0",
+                "o":"200.0",
+                "h":"206.0",
+                "l":"198.0",
+                "v":"20.0",
+                "q":"4100.0"
+              }
+            ]
+        """.trimIndent()
+
+        val parsed = parser.parse(raw)
+
+        assertTrue(parsed is WsMarketMessage.AllMiniTickers)
+        val message = parsed as WsMarketMessage.AllMiniTickers
+        assertEquals(2, message.tickers.size)
+        assertEquals("BTCUSDT", message.tickers.first().symbol)
+        assertEquals("102.5", message.tickers.first().lastPrice)
+    }
+}

--- a/core/network/src/test/java/io/soma/cryptobook/core/network/session/DefaultWsSessionManagerTest.kt
+++ b/core/network/src/test/java/io/soma/cryptobook/core/network/session/DefaultWsSessionManagerTest.kt
@@ -95,11 +95,9 @@ class DefaultWsSessionManagerTest {
         every { transport.isConnected } returns false
         every { transport.connect() } answers {
             onConnect()
-            Unit
         }
         every { transport.disconnect() } answers {
             onDisconnect()
-            Unit
         }
         every { transport.subscribe(any()) } just runs
         every { transport.unsubscribe(any()) } just runs

--- a/core/network/src/test/java/io/soma/cryptobook/core/network/session/DefaultWsSessionManagerTest.kt
+++ b/core/network/src/test/java/io/soma/cryptobook/core/network/session/DefaultWsSessionManagerTest.kt
@@ -6,22 +6,23 @@ import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
 import io.soma.cryptobook.core.network.BinanceWebSocketClient
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 
 class DefaultWsSessionManagerTest {
 
     @Test
     fun `acquire called concurrently connects only once`() = runTest {
-        val transportEvents = MutableSharedFlow<BinanceWebSocketClient.Event>(extraBufferCapacity = 16)
+        val transportEvents =
+            MutableSharedFlow<BinanceWebSocketClient.Event>(extraBufferCapacity = 16)
         val connectCalls = AtomicInteger(0)
         val transport = mockTransport(
             events = transportEvents,
@@ -42,30 +43,32 @@ class DefaultWsSessionManagerTest {
     }
 
     @Test
-    fun `release called concurrently disconnects only once when consumers drain to zero`() = runTest {
-        val transportEvents = MutableSharedFlow<BinanceWebSocketClient.Event>(extraBufferCapacity = 16)
-        val disconnectCalls = AtomicInteger(0)
-        val transport = mockTransport(
-            events = transportEvents,
-            onDisconnect = { disconnectCalls.incrementAndGet() },
-        )
-        val manager = createManager(
-            transport = transport,
-            scope = backgroundScope,
-        )
+    fun `release called concurrently disconnects only once when consumers drain to zero`() =
+        runTest {
+            val transportEvents =
+                MutableSharedFlow<BinanceWebSocketClient.Event>(extraBufferCapacity = 16)
+            val disconnectCalls = AtomicInteger(0)
+            val transport = mockTransport(
+                events = transportEvents,
+                onDisconnect = { disconnectCalls.incrementAndGet() },
+            )
+            val manager = createManager(
+                transport = transport,
+                scope = backgroundScope,
+            )
 
-        repeat(8) {
-            manager.acquire()
+            repeat(8) {
+                manager.acquire()
+            }
+
+            runConcurrently(times = 8) {
+                manager.release()
+            }
+
+            assertEquals(1, disconnectCalls.get())
+            assertEquals(WsSessionState.Stopped, manager.state.value)
+            verify(exactly = 1) { transport.disconnect() }
         }
-
-        runConcurrently(times = 8) {
-            manager.release()
-        }
-
-        assertEquals(1, disconnectCalls.get())
-        assertEquals(WsSessionState.Stopped, manager.state.value)
-        verify(exactly = 1) { transport.disconnect() }
-    }
 
     private fun createManager(
         transport: BinanceWebSocketClient,
@@ -103,10 +106,7 @@ class DefaultWsSessionManagerTest {
         return transport
     }
 
-    private fun runConcurrently(
-        times: Int,
-        action: () -> Unit,
-    ) {
+    private fun runConcurrently(times: Int, action: () -> Unit) {
         val executor = Executors.newFixedThreadPool(times)
         val ready = CountDownLatch(times)
         val start = CountDownLatch(1)

--- a/home/data/build.gradle.kts
+++ b/home/data/build.gradle.kts
@@ -7,6 +7,10 @@ plugins {
 
 android {
     namespace = "io.soma.cryptobook.home.data"
+
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+    }
 }
 
 dependencies {
@@ -17,6 +21,8 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.mockk)
 
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.okhttp.logging)

--- a/home/data/src/main/java/io/soma/cryptobook/home/data/datasource/CoinListStreamDataSource.kt
+++ b/home/data/src/main/java/io/soma/cryptobook/home/data/datasource/CoinListStreamDataSource.kt
@@ -7,11 +7,13 @@ import io.soma.cryptobook.core.network.BinanceWebSocketClient
 import io.soma.cryptobook.core.network.market.WsMarketMessage
 import io.soma.cryptobook.core.network.market.WsMarketMessageRouter
 import io.soma.cryptobook.core.network.market.WsMarketStreamEvent
-import io.soma.cryptobook.core.network.market.WsTickerPayload
+import io.soma.cryptobook.core.network.market.WsMiniTickerPayload
 import io.soma.cryptobook.core.network.session.WsSessionManager
 import io.soma.cryptobook.core.network.subscription.WsSubscriptionFailure
 import io.soma.cryptobook.core.network.subscription.WsSubscriptionManager
 import io.soma.cryptobook.core.network.subscription.WsSubscriptionMethod
+import java.math.BigDecimal
+import java.math.RoundingMode
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
@@ -24,7 +26,7 @@ class CoinListStreamDataSource @Inject constructor(
     private val tickerTable: WsTickerTable,
     private val marketMessageRouter: WsMarketMessageRouter,
 ) {
-    private val targetStream = "!ticker@arr"
+    private val targetStream = "!miniTicker@arr"
 
     // Home feature owns the lifecycle of the market overview stream for now.
     fun maintainCoinListStream(): Flow<Throwable> = flow {
@@ -45,7 +47,7 @@ class CoinListStreamDataSource @Inject constructor(
                         when (val event = streamEvent.event) {
                             is WsMarketStreamEvent.Market -> {
                                 val message = event.message
-                                if (message is WsMarketMessage.AllTickers) {
+                                if (message is WsMarketMessage.AllMiniTickers) {
                                     val tickers = message.tickers.map { it.toCoinTickerDto() }
                                     tickerTable.upsertAll(tickers)
                                 }
@@ -94,14 +96,36 @@ class CoinListStreamDataSource @Inject constructor(
         data class SubscriptionFailure(val failure: WsSubscriptionFailure) : StreamEvent
     }
 
-    private fun WsTickerPayload.toCoinTickerDto(): CoinTickerDto = CoinTickerDto(
-        symbol = symbol,
-        lastPrice = lastPrice,
-        priceChangePercent = priceChangePercent,
-        priceChange = priceChange,
-        lowPrice = lowPrice,
-        highPrice = highPrice,
-        quoteAssetVolume = quoteAssetVolume,
-        openPrice = openPrice,
-    )
+    private fun WsMiniTickerPayload.toCoinTickerDto(): CoinTickerDto {
+        val openPriceDecimal = openPrice.toBigDecimalOrNull()
+        val lastPriceDecimal = lastPrice.toBigDecimalOrNull()
+        val priceChange = if (openPriceDecimal != null && lastPriceDecimal != null) {
+            lastPriceDecimal.subtract(openPriceDecimal)
+        } else {
+            BigDecimal.ZERO
+        }
+        val priceChangePercent = if (
+            openPriceDecimal == null ||
+            lastPriceDecimal == null ||
+            openPriceDecimal.compareTo(BigDecimal.ZERO) == 0
+        ) {
+            BigDecimal.ZERO
+        } else {
+            priceChange
+                .multiply(BigDecimal("100"))
+                .divide(openPriceDecimal, 8, RoundingMode.HALF_UP)
+        }
+
+        return CoinTickerDto(
+            symbol = symbol,
+            lastPrice = lastPrice,
+            priceChangePercent = priceChangePercent.stripTrailingZeros().toPlainString(),
+            priceChange = priceChange.stripTrailingZeros().toPlainString(),
+            lowPrice = lowPrice,
+            highPrice = highPrice,
+            quoteAssetVolume = quoteAssetVolume,
+            openPrice = openPrice,
+        )
+    }
 }
+

--- a/home/data/src/main/java/io/soma/cryptobook/home/data/datasource/CoinListStreamDataSource.kt
+++ b/home/data/src/main/java/io/soma/cryptobook/home/data/datasource/CoinListStreamDataSource.kt
@@ -12,12 +12,12 @@ import io.soma.cryptobook.core.network.session.WsSessionManager
 import io.soma.cryptobook.core.network.subscription.WsSubscriptionFailure
 import io.soma.cryptobook.core.network.subscription.WsSubscriptionManager
 import io.soma.cryptobook.core.network.subscription.WsSubscriptionMethod
-import java.math.BigDecimal
-import java.math.RoundingMode
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
+import java.math.BigDecimal
+import java.math.RoundingMode
 import javax.inject.Inject
 
 class CoinListStreamDataSource @Inject constructor(
@@ -60,7 +60,10 @@ class CoinListStreamDataSource @Inject constructor(
                                     is BinanceWebSocketClient.Event.Disconnected -> Unit
 
                                     is BinanceWebSocketClient.Event.Error -> {
-                                        if (transportEvent.throwable is WebSocketReconnectExhaustedException) {
+                                        val reconnectExhausted =
+                                            transportEvent.throwable is
+                                                WebSocketReconnectExhaustedException
+                                        if (reconnectExhausted) {
                                             emit(transportEvent.throwable)
                                         }
                                     }
@@ -128,4 +131,3 @@ class CoinListStreamDataSource @Inject constructor(
         )
     }
 }
-

--- a/home/data/src/main/java/io/soma/cryptobook/home/data/network/BinanceApiService.kt
+++ b/home/data/src/main/java/io/soma/cryptobook/home/data/network/BinanceApiService.kt
@@ -5,6 +5,6 @@ import retrofit2.Response
 import retrofit2.http.GET
 
 interface BinanceApiService {
-    @GET("fapi/v1/ticker/24hr")
+    @GET("api/v3/ticker/24hr")
     suspend fun getAllTickerPrices(): Response<List<BinanceTickerDto>>
 }

--- a/home/data/src/test/java/io/soma/cryptobook/home/data/repository/CoinRepositoryImplTest.kt
+++ b/home/data/src/test/java/io/soma/cryptobook/home/data/repository/CoinRepositoryImplTest.kt
@@ -1,0 +1,98 @@
+package io.soma.cryptobook.home.data.repository
+
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.soma.cryptobook.core.data.model.CoinTickerDto
+import io.soma.cryptobook.core.data.realtime.ticker.InMemoryWsTickerTable
+import io.soma.cryptobook.home.data.datasource.CoinListRemoteDataSource
+import io.soma.cryptobook.home.data.datasource.CoinListStreamDataSource
+import io.soma.cryptobook.home.data.mapper.CoinPriceDomainModelMapper
+import io.soma.cryptobook.home.data.model.BinanceTickerDto
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CoinRepositoryImplTest {
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `observeCoinPrices propagates ticker table updates after initial rest snapshot`() = runTest(testDispatcher) {
+        val remoteDataSource = mockk<CoinListRemoteDataSource>()
+        val streamDataSource = mockk<CoinListStreamDataSource>()
+        val tickerTable = InMemoryWsTickerTable()
+        val repository = CoinRepositoryImpl(
+            coinListRemoteDataSource = remoteDataSource,
+            coinListStreamDataSource = streamDataSource,
+            tickerTable = tickerTable,
+            coinPriceDomainModelMapper = CoinPriceDomainModelMapper(),
+            ioDispatcher = testDispatcher,
+        )
+
+        coEvery { remoteDataSource.getAllTickerPrices() } returns listOf(
+            BinanceTickerDto(
+                symbol = "BTCUSDT",
+                lastPrice = "100.0",
+                priceChangePercent = "1.0",
+            ),
+            BinanceTickerDto(
+                symbol = "ETHUSDT",
+                lastPrice = "200.0",
+                priceChangePercent = "2.0",
+            ),
+        )
+        every { streamDataSource.maintainCoinListStream() } returns emptyFlow()
+
+        val emissions = mutableListOf<List<io.soma.cryptobook.core.domain.model.CoinPriceVO>>()
+        backgroundScope.launch(testDispatcher) {
+            repository.observeCoinPrices()
+                .take(2)
+                .toList(emissions)
+        }
+
+        tickerTable.upsertAll(
+            listOf(
+                CoinTickerDto(
+                    symbol = "BTCUSDT",
+                    lastPrice = "101.5",
+                    priceChangePercent = "1.5",
+                    priceChange = "1.5",
+                    lowPrice = "99.0",
+                    highPrice = "102.0",
+                    quoteAssetVolume = "1000.0",
+                    openPrice = "100.0",
+                ),
+            ),
+        )
+
+        advanceUntilIdle()
+
+        assertEquals(2, emissions.size)
+        assertEquals("100.0", emissions.first().first { it.symbol == "BTCUSDT" }.price.toPlainString())
+        assertEquals("101.5", emissions.last().first { it.symbol == "BTCUSDT" }.price.toPlainString())
+        assertEquals("200.0", emissions.last().first { it.symbol == "ETHUSDT" }.price.toPlainString())
+    }
+}

--- a/home/data/src/test/java/io/soma/cryptobook/home/data/repository/CoinRepositoryImplTest.kt
+++ b/home/data/src/test/java/io/soma/cryptobook/home/data/repository/CoinRepositoryImplTest.kt
@@ -15,8 +15,8 @@ import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -40,7 +40,9 @@ class CoinRepositoryImplTest {
     }
 
     @Test
-    fun `observeCoinPrices propagates ticker table updates after initial rest snapshot`() = runTest(testDispatcher) {
+    fun `observeCoinPrices propagates ticker table updates after initial rest snapshot`() = runTest(
+        testDispatcher,
+    ) {
         val remoteDataSource = mockk<CoinListRemoteDataSource>()
         val streamDataSource = mockk<CoinListStreamDataSource>()
         val tickerTable = InMemoryWsTickerTable()
@@ -91,8 +93,17 @@ class CoinRepositoryImplTest {
         advanceUntilIdle()
 
         assertEquals(2, emissions.size)
-        assertEquals("100.0", emissions.first().first { it.symbol == "BTCUSDT" }.price.toPlainString())
-        assertEquals("101.5", emissions.last().first { it.symbol == "BTCUSDT" }.price.toPlainString())
-        assertEquals("200.0", emissions.last().first { it.symbol == "ETHUSDT" }.price.toPlainString())
+        assertEquals(
+            "100.0",
+            emissions.first().first { it.symbol == "BTCUSDT" }.price.toPlainString(),
+        )
+        assertEquals(
+            "101.5",
+            emissions.last().first { it.symbol == "BTCUSDT" }.price.toPlainString(),
+        )
+        assertEquals(
+            "200.0",
+            emissions.last().first { it.symbol == "ETHUSDT" }.price.toPlainString(),
+        )
     }
 }

--- a/home/presentation/src/main/java/io/soma/cryptobook/home/presentation/HomeViewModel.kt
+++ b/home/presentation/src/main/java/io/soma/cryptobook/home/presentation/HomeViewModel.kt
@@ -8,9 +8,9 @@ import io.soma.cryptobook.core.domain.navigation.AppPage
 import io.soma.cryptobook.core.domain.navigation.NavigationHelper
 import io.soma.cryptobook.core.presentation.MviViewModel
 import io.soma.cryptobook.home.domain.usecase.ObserveCoinListUseCase
-import javax.inject.Inject
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(


### PR DESCRIPTION
  ## 관련 이슈
  - Closes #59

  ## 사전 점검

  - [x] `./gradlew spotlessApply` 실행을 완료하였습니다.
  - [x] 관련 단위 테스트를 실행하였습니다. (`./gradlew :core:network:test :home:data:test`)

  ## 작업 개요

  `home`과 `coin-detail`에서 혼용되고 있던 Binance futures/spot 기준을 spot market 기준으로 재정렬했습니다. REST ticker, symbol ticker snapshot, kline backfill, 홈 전체 ticker 스트림을 모두 동일한 시장 기준으로 맞추고, 홈에서는 `miniTicker` 배열 메시지를 사용하도록 바꾸면서 부족한 파생값(`priceChange`, `priceChangePercent`)은 앱에서 계산하도록 정리했습니다.

  ## 상세 내용
  ### 1️⃣ UI/UX 변경
  - 직접적인 UI 변경은 없음
  - 다만 홈/상세 화면이 같은 시장 기준의 데이터를 사용하도록 정리되어 데이터 일관성이 높아짐

  ### 2️⃣ 로직 및 아키텍처
  - **기존 방식:** home/coin-detail 일부 경로가 futures 기준 구현에 묶여 있었고, 홈 WS는 `!ticker@arr` payload를 전제로 처리
  - **변경 방식:** REST/WS/클라이언트 계층을 Binance spot market 기준으로 통일하고, 홈 WS는 `!miniTicker@arr`를 파싱해 필요한 파생값을 앱에서 계산

  | 구분 | AS-IS (기존) | TO-BE (변경) |
  | :---: | :---: | :---: |
  | REST ticker | futures/spot 기준 혼용 | `api/v3/ticker/24hr` 기준 통일 |
  | coin-detail snapshot | futures ticker client 사용 | spot ticker client 사용 |
  | coin-detail kline backfill | futures kline client 사용 | spot kline client 사용 |
  | home market stream | `!ticker@arr` 기준 파싱 | `!miniTicker@arr` 기준 파싱 |
  | 홈 가격 변화값 | 서버 payload 의존 | `openPrice`, `lastPrice` 기반 직접 계산 |

  ### 3️⃣ 리팩토링
  - `BinanceSpotApiService`, `BinanceSpotKlineClient`, `BinanceSpotTickerClient` 추가
  - 기존 futures 성격의 client/DTO 명칭을 spot market 기준으로 정리
  - `NetworkModule`에서 futures retrofit qualifier 제거 후 spot API 주입 구조로 단순화
  - `WsMarketMessageParser`에 mini ticker array 파싱 로직 추가
  - `CoinListStreamDataSource`에서 `WsMiniTickerPayload`를 `CoinTickerDto`로 변환하도록 수정
  - parser 단위 테스트와 `CoinRepositoryImpl` 단위 테스트 추가

  ## 리뷰어 집중 포인트(참고 사항)
  - 홈 화면에서 `miniTicker` 기반으로 계산한 `priceChange`, `priceChangePercent`가 기존 정렬/표시 정책과 기대값에 맞는지 확인 부탁드립니다.
  - coin-detail의 REST snapshot / kline backfill / websocket ticker가 모두 같은 spot market 기준으로 정렬됐는지 흐름 중심으로 봐주시면 됩니다.

## 후속작업

- [ ] coin 별로 단위 통일해서 home에 하나의 코인만 나오도록 수정 필요(ETHBTC, ETHUSDT... → ETH)