### PR TITLE
feat: cache binance tick sizes during splash

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
     implementation(projects.settings.data)
 
     implementation(libs.androidx.dataStore)
+    implementation(libs.androidx.room.runtime)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.process)
 

--- a/app/src/main/java/io/soma/cryptobook/di/DatabaseModule.kt
+++ b/app/src/main/java/io/soma/cryptobook/di/DatabaseModule.kt
@@ -1,0 +1,30 @@
+package io.soma.cryptobook.di
+
+import android.content.Context
+import androidx.room.Room
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import io.soma.cryptobook.core.data.database.CryptoBookDatabase
+import io.soma.cryptobook.core.data.database.ticksize.SymbolTickSizeDao
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DatabaseModule {
+    @Provides
+    @Singleton
+    fun provideCryptoBookDatabase(@ApplicationContext context: Context): CryptoBookDatabase =
+        Room.databaseBuilder(
+            context,
+            CryptoBookDatabase::class.java,
+            "cryptobook.db",
+        ).build()
+
+    @Provides
+    @Singleton
+    fun provideSymbolTickSizeDao(database: CryptoBookDatabase): SymbolTickSizeDao =
+        database.symbolTickSizeDao()
+}

--- a/app/src/main/java/io/soma/cryptobook/di/NetworkModule.kt
+++ b/app/src/main/java/io/soma/cryptobook/di/NetworkModule.kt
@@ -6,6 +6,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import io.soma.cryptobook.coindetail.data.network.BinanceSpotKlineClient
 import io.soma.cryptobook.coindetail.data.network.BinanceSpotTickerClient
+import io.soma.cryptobook.core.data.datasource.ticksize.BinanceExchangeInfoApiService
 import io.soma.cryptobook.core.data.network.ExchangeApiService
 import io.soma.cryptobook.core.data.realtime.kline.WsKlineTable
 import io.soma.cryptobook.core.data.realtime.market.DefaultMarketRealtimeCoordinator
@@ -91,6 +92,12 @@ object NetworkModule {
     @Singleton
     fun provideBinanceApiService(@BinanceNetwork retrofit: Retrofit): BinanceApiService =
         retrofit.create(BinanceApiService::class.java)
+
+    @Provides
+    @Singleton
+    fun provideBinanceExchangeInfoApiService(
+        @BinanceNetwork retrofit: Retrofit,
+    ): BinanceExchangeInfoApiService = retrofit.create(BinanceExchangeInfoApiService::class.java)
 
     @Provides
     @Singleton

--- a/app/src/main/java/io/soma/cryptobook/di/RepositoryModule.kt
+++ b/app/src/main/java/io/soma/cryptobook/di/RepositoryModule.kt
@@ -11,8 +11,10 @@ import io.soma.cryptobook.core.data.realtime.kline.WsKlineTable
 import io.soma.cryptobook.core.data.realtime.ticker.InMemoryWsTickerTable
 import io.soma.cryptobook.core.data.realtime.ticker.WsTickerTable
 import io.soma.cryptobook.core.data.repository.ExchangeRateRepositoryImpl
+import io.soma.cryptobook.core.data.repository.TickSizeRepositoryImpl
 import io.soma.cryptobook.core.domain.repository.CoinRepository
 import io.soma.cryptobook.core.domain.repository.ExchangeRateRepository
+import io.soma.cryptobook.core.domain.repository.TickSizeRepository
 import io.soma.cryptobook.home.data.repository.CoinRepositoryImpl
 import javax.inject.Singleton
 
@@ -28,6 +30,10 @@ abstract class RepositoryModule {
     abstract fun bindExchangeRateRepository(
         impl: ExchangeRateRepositoryImpl,
     ): ExchangeRateRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindTickSizeRepository(impl: TickSizeRepositoryImpl): TickSizeRepository
 
     @Binds
     @Singleton

--- a/coin-detail/data/src/main/java/io/soma/cryptobook/coindetail/data/mapper/CoinDetailDomainModelMapper.kt
+++ b/coin-detail/data/src/main/java/io/soma/cryptobook/coindetail/data/mapper/CoinDetailDomainModelMapper.kt
@@ -2,17 +2,20 @@ package io.soma.cryptobook.coindetail.data.mapper
 
 import io.soma.cryptobook.coindetail.domain.model.CoinDetailVO
 import io.soma.cryptobook.core.data.model.CoinTickerDto
+import java.math.BigDecimal
 import javax.inject.Inject
 
 class CoinDetailDomainModelMapper @Inject constructor() {
-    fun toDomainModel(coinTickerDto: CoinTickerDto): CoinDetailVO = CoinDetailVO(
-        symbol = coinTickerDto.symbol,
-        currentPrice = coinTickerDto.lastPrice.toBigDecimal(),
-        priceChange = coinTickerDto.priceChange.toBigDecimal(),
-        priceChangePercent = coinTickerDto.priceChangePercent.toDouble(),
-        high24h = coinTickerDto.highPrice.toBigDecimal(),
-        low24h = coinTickerDto.lowPrice.toBigDecimal(),
-        volume24h = coinTickerDto.quoteAssetVolume.toBigDecimal(),
-        openPrice = coinTickerDto.openPrice.toBigDecimal(),
-    )
+    fun toDomainModel(coinTickerDto: CoinTickerDto, tickSize: BigDecimal? = null): CoinDetailVO =
+        CoinDetailVO(
+            symbol = coinTickerDto.symbol,
+            currentPrice = coinTickerDto.lastPrice.toBigDecimal(),
+            priceChange = coinTickerDto.priceChange.toBigDecimal(),
+            priceChangePercent = coinTickerDto.priceChangePercent.toDouble(),
+            high24h = coinTickerDto.highPrice.toBigDecimal(),
+            low24h = coinTickerDto.lowPrice.toBigDecimal(),
+            volume24h = coinTickerDto.quoteAssetVolume.toBigDecimal(),
+            openPrice = coinTickerDto.openPrice.toBigDecimal(),
+            tickSize = tickSize,
+        )
 }

--- a/coin-detail/data/src/main/java/io/soma/cryptobook/coindetail/data/repository/CoinDetailRepositoryImpl.kt
+++ b/coin-detail/data/src/main/java/io/soma/cryptobook/coindetail/data/repository/CoinDetailRepositoryImpl.kt
@@ -6,6 +6,7 @@ import io.soma.cryptobook.coindetail.data.mapper.CoinDetailDomainModelMapper
 import io.soma.cryptobook.coindetail.domain.model.CoinCandleVO
 import io.soma.cryptobook.coindetail.domain.model.CoinDetailStreamState
 import io.soma.cryptobook.coindetail.domain.repository.CoinDetailRepository
+import io.soma.cryptobook.core.data.database.ticksize.SymbolTickSizeDao
 import io.soma.cryptobook.core.data.model.CoinKlineDto
 import io.soma.cryptobook.core.data.realtime.kline.WsKlineTable
 import io.soma.cryptobook.core.data.realtime.market.MarketRealtimeCoordinator
@@ -36,6 +37,7 @@ constructor(
     private val klineBackfillDataSource: CoinDetailKlineBackfillDataSource,
     private val tickerTable: WsTickerTable,
     private val klineTable: WsKlineTable,
+    private val tickSizeDao: SymbolTickSizeDao,
     private val coinDetailDomainModelMapper: CoinDetailDomainModelMapper,
     private val ioDispatcher: CoroutineDispatcher,
 ) : CoinDetailRepository {
@@ -55,12 +57,16 @@ constructor(
                     klineTable.observe(targetSymbol, TARGET_INTERVAL).map { candles ->
                         candles.map { it.toCoinCandleVO() }
                     },
-                ) { ticker, candles ->
+                    tickSizeDao.observeTickSize(targetSymbol).map { it?.toBigDecimalOrNull() },
+                ) { ticker, candles, tickSize ->
                     if (ticker == null) {
                         CoinDetailStreamState.Loading
                     } else {
                         CoinDetailStreamState.Data(
-                            value = coinDetailDomainModelMapper.toDomainModel(ticker),
+                            value = coinDetailDomainModelMapper.toDomainModel(
+                                coinTickerDto = ticker,
+                                tickSize = tickSize,
+                            ),
                             candles = candles,
                         )
                     }

--- a/coin-detail/domain/src/main/java/io/soma/cryptobook/coindetail/domain/model/CoinDetailVO.kt
+++ b/coin-detail/domain/src/main/java/io/soma/cryptobook/coindetail/domain/model/CoinDetailVO.kt
@@ -25,4 +25,5 @@ data class CoinDetailVO(
     val low24h: BigDecimal,
     val volume24h: BigDecimal,
     val openPrice: BigDecimal,
+    val tickSize: BigDecimal? = null,
 )

--- a/coin-detail/presentation/src/main/java/io/soma/cryptobook/coindetail/presentation/CoinDetailContract.kt
+++ b/coin-detail/presentation/src/main/java/io/soma/cryptobook/coindetail/presentation/CoinDetailContract.kt
@@ -3,6 +3,7 @@ package io.soma.cryptobook.coindetail.presentation
 import io.soma.cryptobook.core.presentation.Event
 import io.soma.cryptobook.core.presentation.SideEffect
 import io.soma.cryptobook.core.presentation.UiState
+import java.math.BigDecimal
 
 data class CoinDetailUiState(
     val symbol: String = "",
@@ -15,6 +16,7 @@ data class CoinDetailUiState(
     val low24h: String = "",
     val volume24h: String = "",
     val openPrice: String = "",
+    val tickSize: BigDecimal? = null,
     val isLoading: Boolean = true,
     val errorMsg: String? = null,
     val realtimeStatusMessage: String? = null,

--- a/coin-detail/presentation/src/main/java/io/soma/cryptobook/coindetail/presentation/CoinDetailScreen.kt
+++ b/coin-detail/presentation/src/main/java/io/soma/cryptobook/coindetail/presentation/CoinDetailScreen.kt
@@ -126,6 +126,7 @@ private fun CoinDetailContent(state: CoinDetailUiState, modifier: Modifier = Mod
 
         CoinCandlestickChart(
             candles = state.candles,
+            tickSize = state.tickSize,
             modifier = Modifier
                 .fillMaxWidth()
                 .height(220.dp)

--- a/coin-detail/presentation/src/main/java/io/soma/cryptobook/coindetail/presentation/component/CoinCandlestickChart.kt
+++ b/coin-detail/presentation/src/main/java/io/soma/cryptobook/coindetail/presentation/component/CoinCandlestickChart.kt
@@ -24,11 +24,16 @@ import com.patrykandpatrick.vico.compose.cartesian.rememberCartesianChart
 import com.patrykandpatrick.vico.compose.cartesian.rememberVicoScrollState
 import com.patrykandpatrick.vico.compose.cartesian.rememberVicoZoomState
 import io.soma.cryptobook.coindetail.presentation.CandleUiModel
+import java.math.BigDecimal
 
 private const val START_AXIS_LABEL_COUNT = 5
 
 @Composable
-fun CoinCandlestickChart(candles: List<CandleUiModel>, modifier: Modifier = Modifier) {
+fun CoinCandlestickChart(
+    candles: List<CandleUiModel>,
+    tickSize: BigDecimal?,
+    modifier: Modifier = Modifier,
+) {
     val modelProducer = remember { CartesianChartModelProducer() }
     val scrollState = rememberVicoScrollState(
         initialScroll = Scroll.Absolute.End,
@@ -42,6 +47,7 @@ fun CoinCandlestickChart(candles: List<CandleUiModel>, modifier: Modifier = Modi
     )
     val renderState = rememberCoinCandlestickChartRenderState(
         candles = candles,
+        tickSize = tickSize,
         scrollState = scrollState,
         zoomState = zoomState,
     )

--- a/coin-detail/presentation/src/main/java/io/soma/cryptobook/coindetail/presentation/component/CoinCandlestickChartSupport.kt
+++ b/coin-detail/presentation/src/main/java/io/soma/cryptobook/coindetail/presentation/component/CoinCandlestickChartSupport.kt
@@ -13,7 +13,8 @@ import com.patrykandpatrick.vico.compose.cartesian.data.CartesianLayerRangeProvi
 import com.patrykandpatrick.vico.compose.cartesian.data.CartesianValueFormatter
 import com.patrykandpatrick.vico.compose.common.data.ExtraStore
 import io.soma.cryptobook.coindetail.presentation.CandleUiModel
-import java.text.DecimalFormat
+import io.soma.cryptobook.core.presentation.format.TickSizePriceFormatter
+import java.math.BigDecimal
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -50,12 +51,12 @@ internal data class CoinCandlestickChartRenderState(
 @Composable
 internal fun rememberCoinCandlestickChartRenderState(
     candles: List<CandleUiModel>,
+    tickSize: BigDecimal?,
     scrollState: VicoScrollState,
     zoomState: VicoZoomState,
 ): CoinCandlestickChartRenderState {
     val density = LocalDensity.current
     val timeFormatter = remember { SimpleDateFormat("yy.MM.dd", Locale.getDefault()) }
-    val priceFormatter = remember { DecimalFormat("#,##0.########") }
     val candleBodyWidthPx = remember(density) {
         with(density) { DEFAULT_CANDLE_BODY_WIDTH.toPx() }
     }
@@ -102,9 +103,9 @@ internal fun rememberCoinCandlestickChartRenderState(
                 ?: " "
         }
     }
-    val startAxisFormatter = remember(priceFormatter) {
+    val startAxisFormatter = remember(tickSize) {
         CartesianValueFormatter { _, value, _ ->
-            priceFormatter.format(value)
+            TickSizePriceFormatter.format(value, tickSize)
         }
     }
 

--- a/coin-detail/presentation/src/main/java/io/soma/cryptobook/coindetail/presentation/mapper/CoinDetailPresentationModelMapper.kt
+++ b/coin-detail/presentation/src/main/java/io/soma/cryptobook/coindetail/presentation/mapper/CoinDetailPresentationModelMapper.kt
@@ -4,9 +4,9 @@ import io.soma.cryptobook.coindetail.domain.model.CoinCandleVO
 import io.soma.cryptobook.coindetail.domain.model.CoinDetailVO
 import io.soma.cryptobook.coindetail.presentation.CandleUiModel
 import io.soma.cryptobook.coindetail.presentation.CoinDetailUiState
+import io.soma.cryptobook.core.presentation.format.TickSizePriceFormatter
 import java.math.BigDecimal
 import java.math.RoundingMode
-import java.text.DecimalFormat
 import javax.inject.Inject
 
 /**
@@ -33,14 +33,15 @@ class CoinDetailPresentationModelMapper @Inject constructor() {
         return CoinDetailUiState(
             symbol = vo.symbol,
             imageUrl = imageUrl,
-            currentPrice = formatPrice(vo.currentPrice),
-            priceChangeText = formatPriceChange(vo.priceChange, vo.priceChangePercent),
+            currentPrice = formatPrice(vo.currentPrice, vo.tickSize),
+            priceChangeText = formatPriceChange(vo.priceChange, vo.priceChangePercent, vo.tickSize),
             priceChangePercent = vo.priceChangePercent,
             candles = candles.map { it.toUiModel() },
-            high24h = formatPrice(vo.high24h),
-            low24h = formatPrice(vo.low24h),
+            high24h = formatPrice(vo.high24h, vo.tickSize),
+            low24h = formatPrice(vo.low24h, vo.tickSize),
             volume24h = formatVolume(vo.volume24h),
-            openPrice = formatPrice(vo.openPrice),
+            openPrice = formatPrice(vo.openPrice, vo.tickSize),
+            tickSize = vo.tickSize,
             isLoading = isLoading,
             errorMsg = errorMsg,
         )
@@ -49,11 +50,8 @@ class CoinDetailPresentationModelMapper @Inject constructor() {
     /**
      * Formats price as "$70,123.45"
      */
-    private fun formatPrice(value: BigDecimal): String {
-        val formatter = DecimalFormat("#,##0.00")
-        val rounded = value.setScale(2, RoundingMode.HALF_UP)
-        return "$${formatter.format(rounded)}"
-    }
+    private fun formatPrice(value: BigDecimal, tickSize: BigDecimal?): String =
+        TickSizePriceFormatter.formatUsd(value, tickSize)
 
     /**
      * Formats volume with appropriate unit
@@ -80,22 +78,24 @@ class CoinDetailPresentationModelMapper @Inject constructor() {
                 val result = value.divide(thousand, 1, RoundingMode.HALF_UP)
                 "$${result}K"
             }
-            else -> formatPrice(value)
+            else -> TickSizePriceFormatter.formatUsd(value, tickSize = null)
         }
     }
 
     /**
      * Formats price change as "+1,840.55 (+2.58%)" or "-1,840.55 (-2.58%)"
      */
-    private fun formatPriceChange(priceChange: BigDecimal, priceChangePercent: Double): String {
-        val formatter = DecimalFormat("#,##0.00")
-        val rounded = priceChange.setScale(2, RoundingMode.HALF_UP)
-        val sign = if (priceChangePercent >= 0) "+" else ""
-
-        val priceChangeFormatted = formatter.format(rounded.abs())
+    private fun formatPriceChange(
+        priceChange: BigDecimal,
+        priceChangePercent: Double,
+        tickSize: BigDecimal?,
+    ): String {
+        val priceSign = if (priceChangePercent >= 0) "+" else "-"
+        val percentSign = if (priceChangePercent >= 0) "+" else ""
+        val priceChangeFormatted = TickSizePriceFormatter.format(priceChange.abs(), tickSize)
         val percentFormatted = String.format("%.2f", priceChangePercent)
 
-        return "$sign$$priceChangeFormatted ($sign$percentFormatted%)"
+        return "$priceSign$$priceChangeFormatted ($percentSign$percentFormatted%)"
     }
 
     private fun CoinCandleVO.toUiModel(): CandleUiModel = CandleUiModel(

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -55,7 +55,10 @@ dependencies {
     implementation(libs.retrofit.core)
     implementation(libs.retrofit.kotlin.serialization)
     implementation(libs.androidx.dataStore)
+    implementation(libs.androidx.room.runtime)
+    implementation(libs.androidx.room.ktx)
     implementation(libs.protobuf.kotlin.lite)
+    ksp(libs.androidx.room.compiler)
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/core/data/src/main/java/io/soma/cryptobook/core/data/database/CryptoBookDatabase.kt
+++ b/core/data/src/main/java/io/soma/cryptobook/core/data/database/CryptoBookDatabase.kt
@@ -1,0 +1,17 @@
+package io.soma.cryptobook.core.data.database
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import io.soma.cryptobook.core.data.database.ticksize.SymbolTickSizeDao
+import io.soma.cryptobook.core.data.database.ticksize.SymbolTickSizeEntity
+
+@Database(
+    entities = [
+        SymbolTickSizeEntity::class,
+    ],
+    version = 1,
+    exportSchema = false,
+)
+abstract class CryptoBookDatabase : RoomDatabase() {
+    abstract fun symbolTickSizeDao(): SymbolTickSizeDao
+}

--- a/core/data/src/main/java/io/soma/cryptobook/core/data/database/ticksize/SymbolTickSizeDao.kt
+++ b/core/data/src/main/java/io/soma/cryptobook/core/data/database/ticksize/SymbolTickSizeDao.kt
@@ -1,0 +1,29 @@
+package io.soma.cryptobook.core.data.database.ticksize
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface SymbolTickSizeDao {
+    @Query("SELECT * FROM symbol_tick_sizes")
+    fun observeAll(): Flow<List<SymbolTickSizeEntity>>
+
+    @Query("SELECT tickSize FROM symbol_tick_sizes WHERE symbol = :symbol")
+    fun observeTickSize(symbol: String): Flow<String?>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertAll(tickSizes: List<SymbolTickSizeEntity>)
+
+    @Query("DELETE FROM symbol_tick_sizes")
+    suspend fun clear()
+
+    @Transaction
+    suspend fun replaceAll(tickSizes: List<SymbolTickSizeEntity>) {
+        clear()
+        upsertAll(tickSizes)
+    }
+}

--- a/core/data/src/main/java/io/soma/cryptobook/core/data/database/ticksize/SymbolTickSizeEntity.kt
+++ b/core/data/src/main/java/io/soma/cryptobook/core/data/database/ticksize/SymbolTickSizeEntity.kt
@@ -1,0 +1,10 @@
+package io.soma.cryptobook.core.data.database.ticksize
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "symbol_tick_sizes")
+data class SymbolTickSizeEntity(
+    @PrimaryKey val symbol: String,
+    val tickSize: String,
+)

--- a/core/data/src/main/java/io/soma/cryptobook/core/data/datasource/ticksize/BinanceExchangeInfoApiService.kt
+++ b/core/data/src/main/java/io/soma/cryptobook/core/data/datasource/ticksize/BinanceExchangeInfoApiService.kt
@@ -1,0 +1,10 @@
+package io.soma.cryptobook.core.data.datasource.ticksize
+
+import io.soma.cryptobook.core.data.model.ticksize.BinanceExchangeInfoDto
+import retrofit2.Response
+import retrofit2.http.GET
+
+interface BinanceExchangeInfoApiService {
+    @GET("api/v3/exchangeInfo")
+    suspend fun getExchangeInfo(): Response<BinanceExchangeInfoDto>
+}

--- a/core/data/src/main/java/io/soma/cryptobook/core/data/datasource/ticksize/TickSizeRemoteDataSource.kt
+++ b/core/data/src/main/java/io/soma/cryptobook/core/data/datasource/ticksize/TickSizeRemoteDataSource.kt
@@ -1,0 +1,13 @@
+package io.soma.cryptobook.core.data.datasource.ticksize
+
+import io.soma.cryptobook.core.data.model.ticksize.BinanceExchangeInfoDto
+import io.soma.cryptobook.core.network.base.BaseDataSource
+import javax.inject.Inject
+
+class TickSizeRemoteDataSource @Inject constructor(
+    private val apiService: BinanceExchangeInfoApiService,
+) : BaseDataSource() {
+    suspend fun getExchangeInfo(): BinanceExchangeInfoDto = checkResponse(
+        apiService.getExchangeInfo(),
+    )
+}

--- a/core/data/src/main/java/io/soma/cryptobook/core/data/datastore/CbPreferencesDataSource.kt
+++ b/core/data/src/main/java/io/soma/cryptobook/core/data/datastore/CbPreferencesDataSource.kt
@@ -15,6 +15,9 @@ import javax.inject.Inject
 class CbPreferencesDataSource @Inject constructor(
     private val userPreferences: DataStore<UserPreferences>,
 ) {
+    val lastTickSizeCheckedAtMillis = userPreferences.data
+        .map { it.lastTickSizeCheckedAtMillis }
+
     val userData = userPreferences.data
         .map {
             UserData(
@@ -67,6 +70,12 @@ class CbPreferencesDataSource @Inject constructor(
     suspend fun setUsdKrwExchangeRate(usdKrwExchangeRate: Long) {
         userPreferences.updateData {
             it.copy { this.usdKrwExchangeRate = usdKrwExchangeRate }
+        }
+    }
+
+    suspend fun setLastTickSizeCheckedAtMillis(checkedAtMillis: Long) {
+        userPreferences.updateData {
+            it.copy { this.lastTickSizeCheckedAtMillis = checkedAtMillis }
         }
     }
 }

--- a/core/data/src/main/java/io/soma/cryptobook/core/data/model/ticksize/BinanceExchangeInfoDto.kt
+++ b/core/data/src/main/java/io/soma/cryptobook/core/data/model/ticksize/BinanceExchangeInfoDto.kt
@@ -1,0 +1,26 @@
+package io.soma.cryptobook.core.data.model.ticksize
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BinanceExchangeInfoDto(
+    @SerialName("symbols")
+    val symbols: List<BinanceSymbolInfoDto> = emptyList(),
+)
+
+@Serializable
+data class BinanceSymbolInfoDto(
+    @SerialName("symbol")
+    val symbol: String,
+    @SerialName("filters")
+    val filters: List<BinanceSymbolFilterDto> = emptyList(),
+)
+
+@Serializable
+data class BinanceSymbolFilterDto(
+    @SerialName("filterType")
+    val filterType: String,
+    @SerialName("tickSize")
+    val tickSize: String? = null,
+)

--- a/core/data/src/main/java/io/soma/cryptobook/core/data/repository/TickSizeRepositoryImpl.kt
+++ b/core/data/src/main/java/io/soma/cryptobook/core/data/repository/TickSizeRepositoryImpl.kt
@@ -1,0 +1,53 @@
+package io.soma.cryptobook.core.data.repository
+
+import io.soma.cryptobook.core.data.database.ticksize.SymbolTickSizeDao
+import io.soma.cryptobook.core.data.database.ticksize.SymbolTickSizeEntity
+import io.soma.cryptobook.core.data.datasource.ticksize.TickSizeRemoteDataSource
+import io.soma.cryptobook.core.data.datastore.CbPreferencesDataSource
+import io.soma.cryptobook.core.domain.repository.TickSizeRepository
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class TickSizeRepositoryImpl @Inject constructor(
+    private val remoteDataSource: TickSizeRemoteDataSource,
+    private val tickSizeDao: SymbolTickSizeDao,
+    private val preferencesDataSource: CbPreferencesDataSource,
+    private val ioDispatcher: CoroutineDispatcher,
+) : TickSizeRepository {
+    override suspend fun refreshTickSizesIfRequired(nowMillis: Long) = withContext(ioDispatcher) {
+        val lastCheckedAtMillis = preferencesDataSource.lastTickSizeCheckedAtMillis.first()
+        val elapsedMillis = nowMillis - lastCheckedAtMillis
+        if (
+            lastCheckedAtMillis > 0L &&
+            elapsedMillis in 0 until TICK_SIZE_REFRESH_INTERVAL_MILLIS
+        ) {
+            return@withContext
+        }
+
+        val tickSizes = remoteDataSource.getExchangeInfo()
+            .symbols
+            .mapNotNull { symbolInfo ->
+                val tickSize = symbolInfo.filters
+                    .firstOrNull { it.filterType == PRICE_FILTER }
+                    ?.tickSize
+                    ?.takeIf { it.isNotBlank() }
+                    ?: return@mapNotNull null
+
+                SymbolTickSizeEntity(
+                    symbol = symbolInfo.symbol.uppercase(),
+                    tickSize = tickSize,
+                )
+            }
+            .distinctBy { it.symbol }
+
+        tickSizeDao.replaceAll(tickSizes)
+        preferencesDataSource.setLastTickSizeCheckedAtMillis(nowMillis)
+    }
+
+    private companion object {
+        private const val PRICE_FILTER = "PRICE_FILTER"
+        private const val TICK_SIZE_REFRESH_INTERVAL_MILLIS = 24L * 60L * 60L * 1000L
+    }
+}

--- a/core/data/src/main/proto/io/soma/cryptobook/core/data/user_preferences.proto
+++ b/core/data/src/main/proto/io/soma/cryptobook/core/data/user_preferences.proto
@@ -10,4 +10,5 @@ message UserPreferences {
     LanguageProto language = 1;
     CurrencyUnitProto currency_unit = 2;
     int64 usd_krw_exchange_rate = 3;
+    int64 last_tick_size_checked_at_millis = 4;
 }

--- a/core/domain/src/main/java/io/soma/cryptobook/core/domain/model/CoinPriceVO.kt
+++ b/core/domain/src/main/java/io/soma/cryptobook/core/domain/model/CoinPriceVO.kt
@@ -6,4 +6,5 @@ data class CoinPriceVO(
     val symbol: String,
     val price: BigDecimal,
     val priceChangePercentage24h: Double,
+    val tickSize: BigDecimal? = null,
 )

--- a/core/domain/src/main/java/io/soma/cryptobook/core/domain/repository/TickSizeRepository.kt
+++ b/core/domain/src/main/java/io/soma/cryptobook/core/domain/repository/TickSizeRepository.kt
@@ -1,0 +1,5 @@
+package io.soma.cryptobook.core.domain.repository
+
+interface TickSizeRepository {
+    suspend fun refreshTickSizesIfRequired(nowMillis: Long)
+}

--- a/core/domain/src/main/java/io/soma/cryptobook/core/domain/usecase/RefreshTickSizesIfRequiredUseCase.kt
+++ b/core/domain/src/main/java/io/soma/cryptobook/core/domain/usecase/RefreshTickSizesIfRequiredUseCase.kt
@@ -1,0 +1,12 @@
+package io.soma.cryptobook.core.domain.usecase
+
+import io.soma.cryptobook.core.domain.repository.TickSizeRepository
+import javax.inject.Inject
+
+class RefreshTickSizesIfRequiredUseCase @Inject constructor(
+    private val tickSizeRepository: TickSizeRepository,
+) {
+    suspend operator fun invoke(nowMillis: Long = System.currentTimeMillis()) {
+        tickSizeRepository.refreshTickSizesIfRequired(nowMillis)
+    }
+}

--- a/core/presentation/src/main/java/io/soma/cryptobook/core/presentation/format/TickSizePriceFormatter.kt
+++ b/core/presentation/src/main/java/io/soma/cryptobook/core/presentation/format/TickSizePriceFormatter.kt
@@ -1,0 +1,49 @@
+package io.soma.cryptobook.core.presentation.format
+
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.text.DecimalFormat
+
+object TickSizePriceFormatter {
+    fun formatUsd(value: BigDecimal, tickSize: BigDecimal?): String =
+        "$${format(value = value, tickSize = tickSize)}"
+
+    fun format(value: Double, tickSize: BigDecimal?): String =
+        format(value = BigDecimal.valueOf(value), tickSize = tickSize)
+
+    fun format(value: BigDecimal, tickSize: BigDecimal?): String {
+        val validTickSize = tickSize?.takeIf { it.signum() > 0 }
+        val scale = validTickSize?.displayScale() ?: DEFAULT_SCALE
+        val rounded = if (validTickSize == null) {
+            value.setScale(DEFAULT_SCALE, RoundingMode.HALF_UP)
+        } else {
+            value.roundToTick(validTickSize, scale)
+        }
+
+        return decimalFormat(scale).format(rounded)
+    }
+
+    private fun BigDecimal.roundToTick(tickSize: BigDecimal, scale: Int): BigDecimal {
+        val tickCount = divide(tickSize, 0, RoundingMode.HALF_UP)
+        return tickCount
+            .multiply(tickSize)
+            .setScale(scale, RoundingMode.HALF_UP)
+    }
+
+    private fun BigDecimal.displayScale(): Int = stripTrailingZeros()
+        .scale()
+        .coerceAtLeast(0)
+
+    private fun decimalFormat(scale: Int): DecimalFormat {
+        val pattern = if (scale == 0) {
+            "#,##0"
+        } else {
+            "#,##0.${"0".repeat(scale)}"
+        }
+        return DecimalFormat(pattern).apply {
+            roundingMode = RoundingMode.HALF_UP
+        }
+    }
+
+    private const val DEFAULT_SCALE = 2
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,6 +67,9 @@ androidx-dataStore = { group = "androidx.datastore", name = "datastore", version
 androidx-hilt-lifecycle-viewModelCompose = { group = "androidx.hilt", name = "hilt-lifecycle-viewmodel-compose", version.ref = "androidxHiltLifecycleViewModelCompose" }
 androidx-lifecycle-viewModelCompose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "androidxLifecycle" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
+androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
+androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
 hilt-core = { group = "com.google.dagger", name = "hilt-core", version.ref = "hilt" }

--- a/home/data/src/main/java/io/soma/cryptobook/home/data/repository/CoinRepositoryImpl.kt
+++ b/home/data/src/main/java/io/soma/cryptobook/home/data/repository/CoinRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package io.soma.cryptobook.home.data.repository
 
+import io.soma.cryptobook.core.data.database.ticksize.SymbolTickSizeDao
 import io.soma.cryptobook.core.data.realtime.ticker.WsTickerTable
 import io.soma.cryptobook.core.domain.model.CoinInfoVO
 import io.soma.cryptobook.core.domain.model.CoinPriceVO
@@ -9,6 +10,7 @@ import io.soma.cryptobook.home.data.mapper.CoinPriceDomainModelMapper
 import io.soma.cryptobook.home.data.model.toCoinPriceVO
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filter
@@ -16,6 +18,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
+import java.math.BigDecimal
 import javax.inject.Inject
 
 class CoinRepositoryImpl
@@ -23,6 +26,7 @@ class CoinRepositoryImpl
 constructor(
     private val coinListRemoteDataSource: CoinListRemoteDataSource,
     private val tickerTable: WsTickerTable,
+    private val tickSizeDao: SymbolTickSizeDao,
     private val coinPriceDomainModelMapper: CoinPriceDomainModelMapper,
     private val ioDispatcher: CoroutineDispatcher,
 ) : CoinRepository {
@@ -30,35 +34,45 @@ constructor(
         coinListRemoteDataSource.getAllTickerPrices().map { it.toCoinPriceVO() }
     }
 
-    override fun observeCoinPrices(): Flow<List<CoinPriceVO>> = flow {
-        val initialPrices = LinkedHashMap<String, CoinPriceVO>()
-        val initial = runCatching { getCoinPrices() }
-            .getOrDefault(emptyList())
-            .also { prices ->
-                prices.forEach { initialPrices[it.symbol] = it }
+    override fun observeCoinPrices(): Flow<List<CoinPriceVO>> {
+        val pricesFlow = flow {
+            val initialPrices = LinkedHashMap<String, CoinPriceVO>()
+            val initial = runCatching { getCoinPrices() }
+                .getOrDefault(emptyList())
+                .also { prices ->
+                    prices.forEach { initialPrices[it.symbol] = it }
+                }
+
+            val currentTable = tickerTable.table.value
+            val initialEmission = if (currentTable.isEmpty()) {
+                initial
+            } else {
+                mergePrices(
+                    initialPrices = initialPrices,
+                    table = currentTable,
+                )
             }
 
-        val currentTable = tickerTable.table.value
-        val initialEmission = if (currentTable.isEmpty()) {
-            initial
-        } else {
-            mergePrices(
-                initialPrices = initialPrices,
-                table = currentTable,
-            )
+            emit(initialEmission)
+
+            val tableUpdates = tickerTable.table
+                .let { tableFlow ->
+                    if (currentTable.isEmpty()) tableFlow else tableFlow.drop(1)
+                }
+                .filter { it.isNotEmpty() }
+                .map { table -> mergePrices(initialPrices = initialPrices, table = table) }
+
+            emitAll(tableUpdates)
         }
 
-        emit(initialEmission)
+        val tickSizesFlow = tickSizeDao.observeAll().map { entities ->
+            entities.associate { it.symbol to it.tickSize.toBigDecimalOrNull() }
+        }
 
-        val tableUpdates = tickerTable.table
-            .let { tableFlow ->
-                if (currentTable.isEmpty()) tableFlow else tableFlow.drop(1)
-            }
-            .filter { it.isNotEmpty() }
-            .map { table -> mergePrices(initialPrices = initialPrices, table = table) }
-
-        emitAll(tableUpdates)
-    }.flowOn(ioDispatcher)
+        return combine(pricesFlow, tickSizesFlow) { prices, tickSizes ->
+            prices.withTickSizes(tickSizes)
+        }.flowOn(ioDispatcher)
+    }
 
     override suspend fun getCoinInfoList(): List<CoinInfoVO> {
         TODO("Not yet implemented")
@@ -73,5 +87,11 @@ constructor(
             merged[ticker.symbol] = coinPriceDomainModelMapper.toDomainModel(ticker)
         }
         return merged.values.toList()
+    }
+
+    private fun List<CoinPriceVO>.withTickSizes(
+        tickSizes: Map<String, BigDecimal?>,
+    ): List<CoinPriceVO> = map { coinPrice ->
+        coinPrice.copy(tickSize = tickSizes[coinPrice.symbol])
     }
 }

--- a/home/presentation/src/main/java/io/soma/cryptobook/home/presentation/HomeContract.kt
+++ b/home/presentation/src/main/java/io/soma/cryptobook/home/presentation/HomeContract.kt
@@ -18,6 +18,7 @@ data class CoinItem(
     val imageUrl: String,
     val price: BigDecimal,
     val priceChangePercentage24h: Double,
+    val tickSize: BigDecimal? = null,
 )
 
 sealed interface HomeEvent : Event {
@@ -33,4 +34,5 @@ fun CoinPriceVO.toCoinItem(imageUrl: String) = CoinItem(
     imageUrl = imageUrl,
     price = price,
     priceChangePercentage24h = priceChangePercentage24h,
+    tickSize = tickSize,
 )

--- a/home/presentation/src/main/java/io/soma/cryptobook/home/presentation/HomeScreen.kt
+++ b/home/presentation/src/main/java/io/soma/cryptobook/home/presentation/HomeScreen.kt
@@ -21,12 +21,12 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.soma.cryptobook.core.designsystem.theme.ScreenBackground
 import io.soma.cryptobook.core.designsystem.theme.component.CbSearchTopAppBar
+import io.soma.cryptobook.core.presentation.format.TickSizePriceFormatter
 import io.soma.cryptobook.home.presentation.component.coinlist.CoinListItemData
 import io.soma.cryptobook.home.presentation.component.coinlist.CoinListTable
 import io.soma.cryptobook.home.presentation.component.sortheader.SortDirection
 import io.soma.cryptobook.home.presentation.component.sortheader.SortHeader
 import java.math.BigDecimal
-import java.math.RoundingMode
 
 @Composable
 fun HomeRoute(modifier: Modifier = Modifier, viewModel: HomeViewModel = hiltViewModel()) {
@@ -110,7 +110,7 @@ private fun CoinItem.toCoinListItemData() = CoinListItemData(
     symbol = symbol,
     name = symbol.removeSuffix("USDT"),
     imageUrl = imageUrl,
-    price = "$${price.setScale(2, RoundingMode.HALF_UP)}",
+    price = TickSizePriceFormatter.formatUsd(price, tickSize),
     changePercent = priceChangePercentage24h,
 )
 

--- a/splash/presentation/src/main/java/io/soma/cryptobook/splash/presentation/SplashViewModel.kt
+++ b/splash/presentation/src/main/java/io/soma/cryptobook/splash/presentation/SplashViewModel.kt
@@ -7,6 +7,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.soma.cryptobook.core.domain.repository.CoinRepository
 import io.soma.cryptobook.core.domain.usecase.RefreshExchangeRateUseCase
+import io.soma.cryptobook.core.domain.usecase.RefreshTickSizesIfRequiredUseCase
 import io.soma.cryptobook.splash.domain.usecase.CheckUpdateRequirementUseCase
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
@@ -21,6 +22,7 @@ class SplashViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
     private val checkUpdateRequirementUseCase: CheckUpdateRequirementUseCase,
     private val refreshExchangeRateUseCase: RefreshExchangeRateUseCase,
+    private val refreshTickSizesIfRequiredUseCase: RefreshTickSizesIfRequiredUseCase,
     private val coinRepository: CoinRepository,
 ) : ViewModel() {
 
@@ -52,11 +54,22 @@ class SplashViewModel @Inject constructor(
                     }
             }
 
+            val tickSizeJob = async {
+                runCatching { refreshTickSizesIfRequiredUseCase() }
+                    .onFailure { e ->
+                        android.util.Log.e("SplashViewModel", "tickSize 갱신 실패: ${e.message}", e)
+                    }
+                    .onSuccess {
+                        android.util.Log.d("SplashViewModel", "tickSize 갱신 성공")
+                    }
+            }
+
             val delayJob = async { delay(2000) }
 
             val isUpdateRequired = versionCheckJob.await()
             prefetchJob.await()
             exchangeRateJob.await()
+            tickSizeJob.await()
             delayJob.await()
 
             _uiState.value = SplashUiState.Success(isUpdateRequired = isUpdateRequired)


### PR DESCRIPTION
## 관련 이슈
- Closes #48 

## 사전 점검

- [X] `./gradlew spotlessApply` 실행을 완료하였습니다.

## 작업 내용

Binance Spot API의 `PRICE_FILTER.tickSize`를 기준으로 가격 표시 단위를 적용했습니다.

기존에는 홈/상세 화면의 가격이 소수점 2자리로 고정되어 있었지만, 이제 심볼별 tickSize를 저장하고 Room Flow를 통해 구독하여 가격 포맷에 반영합니다.

## 스크린샷

<img width="340" height="552" alt="image" src="https://github.com/user-attachments/assets/7f65f4cf-3564-479b-b20c-84960e2dabeb" />


## 주요 변경

- Binance `/api/v3/exchangeInfo`에서 심볼별 `PRICE_FILTER.tickSize` 수집
- Room에 심볼별 tickSize 캐시 테이블 추가
- DataStore에 마지막 tickSize 확인 시각 저장
- splash 시점에 마지막 확인 시각을 확인하고, 24시간 초과 시 tickSize 갱신
- tickSize 갱신 실패 시 앱 진입은 막지 않고 기존 캐시 또는 2자리 fallback 사용
- 홈 가격, 상세 가격 정보, 상세 차트 Y축 라벨에 tickSize 기반 포맷 적용
- tickSize 기준 반올림은 `HALF_UP` 적용


## 후속 작업

현재 앱의 가격 렌더링은 `$` 표시를 전제로 하고 있으며, 사실상 USDT 마켓만 올바르게 표현할 수 있습니다.

Binance 심볼은 `BASE + QUOTE` 구조이므로 `ETHBTC`의 가격 `0.001`은 `$0.001`이 아니라 `0.001 BTC`를 의미합니다. 따라서 현재 UI 정책을 유지하려면 tickSize 수집과 코인 가격 수집 모두 USDT 마켓 기준으로 필터링해야 합니다.

- tickSize 저장 시 `quoteAsset == "USDT"` 또는 `symbol.endsWith("USDT")`만 저장
- 코인 가격 목록 수집 시 USDT 마켓만 표시
