### PR TITLE
docs: CryptoBook에 맞게 에이전트 가이드 정리

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,129 @@
+# AI Agent Guide for CryptoBook Android
+
+This file defines requirements for AI coding agents and automated systems contributing to this repository.
+
+AI-generated or AI-assisted contributions are acceptable only if they comply with these rules and meet the same
+standards as human-written contributions.
+
+## Applicability
+
+These requirements apply to:
+
+- All modules in this repository
+- All pull requests created fully or partially using AI tools
+- Automated refactoring, formatting, or code generation
+
+## Repository Context
+
+CryptoBook Android is a Kotlin Android application for viewing cryptocurrency market information.
+
+Project documentation resides in the `docs/` directory.
+
+Agents MUST consult relevant documentation before making architectural or structural changes.
+
+## Required Agent Workflow
+
+Before making changes, agents MUST:
+
+### 1. Understand the Request
+
+- Confirm that requirements are clear and consistent with project rules
+- If requirements are incomplete, ambiguous, or conflicting:
+  - **Do NOT guess**
+  - Document assumptions
+  - Request clarification before proceeding
+
+### 2. Research Context
+
+- Read `README.md` and relevant documentation in `docs/`
+- Review existing implementations in affected modules
+
+### 3. Make Changes
+
+- Modify **only** files directly related to the requested change
+- Follow existing patterns and conventions in the affected modules
+- Maintain consistency with the established architecture
+
+## Technology Requirements
+
+Agents MUST use:
+
+- Kotlin for new code
+- Jetpack Compose for UI
+- Hilt for dependency injection
+- Coroutines and Flow for concurrency
+- MVI (Unidirectional Data Flow) pattern (see `docs/architecture/ui-architecture.md`)
+
+Agents MUST NOT introduce alternative frameworks.
+
+## Coding Requirements
+
+Agents MUST:
+
+- Make small, focused, reviewable changes
+- Prioritize security and correctness over convenience or shorter code
+- Modify only files directly related to the requested change
+- Follow the exact naming and formatting conventions of the file and module being modified
+- NOT reformat, modernize, or clean up unrelated code
+- Avoid speculative refactoring
+
+## Security Requirements
+
+Agents MUST NOT:
+
+- Hardcode secrets, credentials, API keys, or tokens
+
+All external input MUST be treated as untrusted. Validate and sanitize user input.
+
+## Commit Requirements
+
+This repository uses Conventional Commits for all commit messages.
+
+Agents MUST:
+
+- Use appropriate prefixes (`feat:`, `fix:`, `refactor:`, `style:`, `test:`, `chore:`)
+- Keep commits small and logically scoped
+- Separate formatting-only changes into `style:` commits
+- Separate refactoring from functional changes
+- Avoid mixing behavior changes and formatting in a single commit
+
+## Pull Request Requirements
+
+Pull requests MUST include:
+
+- A clear description of changes
+- The reason for the change
+- Known risks or trade-offs
+- Disclosure of AI assistance (if applicable)
+
+AI assistance does not reduce review standards.
+
+## Escalation
+
+### When to Stop and Ask
+
+If uncertain about:
+
+- Requirements (incomplete, ambiguous, or conflicting)
+- Architectural decisions
+- Module boundaries or dependencies
+- Technology choices
+- Security implications
+
+**Then:**
+
+1. Stop — Do not proceed with uncertain changes
+2. Document assumptions — Write down what you understand and what's unclear
+3. Request clarification — Ask specific questions
+
+### What NOT to Do
+
+Agents MUST NOT:
+
+- Invent architecture or design patterns
+- Bypass module boundaries to "make it work"
+- Prioritize elegance over established project conventions
+- Guess at requirements or implementation details
+- Make breaking changes without explicit approval
+
+When in doubt, ask. It's always better to clarify than to guess wrong.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,15 @@ Agents MUST NOT:
 
 All external input MUST be treated as untrusted. Validate and sanitize user input.
 
+## Build and Verification Requirements
+
+Before proposing changes, agents MUST run the narrowest relevant Gradle tasks and ensure they pass.
+
+### Code Quality
+
+- `./gradlew spotlessCheck`
+- `./gradlew spotlessApply` (to fix formatting issues)
+
 ## Commit Requirements
 
 This repository uses Conventional Commits for all commit messages.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## 요약

Thunderbird Android 기반의 `AGENTS.md`를 현재 CryptoBook Android 프로젝트 맥락에 맞게 정리했습니다.

## 변경 내용

- 프로젝트 설명을 Thunderbird/K-9 Mail에서 CryptoBook Android 기준으로 수정
- DI 기준을 `Koin`에서 `Hilt`로 변경
- 문서 참조를 `README.md`와 `docs/` 기준으로 정리
- 현재 프로젝트와 맞지 않는 내용을 삭제
  - Thunderbird/K-9 Mail 및 white-label 구조
  - 모듈 구조와 API/internal boundary 설명
  - Design system 관련 요구사항
  - 테스트 정책 및 테스트 라이브러리 설명
  - Thunderbird 전용 logging/privacy 설명
  - 현재 프로젝트 맥락에 맞지 않는 security 항목
  - Gradle 검증 명령 섹션

## 유지한 내용

- AI-assisted contribution 기본 원칙
- 작은 범위의 변경과 기존 패턴 준수 원칙
- Kotlin, Jetpack Compose, Coroutines/Flow, MVI 사용 원칙
- secret/API key/token 하드코딩 금지
- Conventional Commits 및 PR 작성 원칙
- 불확실한 경우 중단하고 질문하는 escalation 원칙

## 리뷰 요청

- 원본 문서와 현재 문서의 차이점을 먼저 확인해주세요.
- 현재 문서를 한글로 번역해서 반드시 전체 내용을 읽어봐 주세요.
- 번역해서 읽었을 때 어색하거나 현재 프로젝트 방향과 맞지 않는 표현이 있다면 리뷰 코멘트로 남겨주세요.